### PR TITLE
fix: search, CORS, profile indexing, batch phone search

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -50,7 +50,7 @@ EXPOSE 3001 50051
 
 # Health check (ensure dist/docker/health-check.js is produced by build)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD ["dist/docker/health-check.js"]
+    CMD ["/nodejs/bin/node", "dist/docker/health-check.js"]
 
 # Start the application with environment checks (use compiled TS in dist)
 # Note: distroless images have 'node' as default ENTRYPOINT, so we only specify the script

--- a/src/docker/health-check.ts
+++ b/src/docker/health-check.ts
@@ -14,8 +14,8 @@ const timestamp = () => new Date().toISOString();
 
 const options: RequestOptions = {
 	hostname: 'localhost',
-	port: 3001,
-	path: '/health/ready',
+	port: parseInt(process.env.HTTP_PORT || '3011', 10),
+	path: '/user/v1/health/ready',
 	method: 'GET',
 	timeout: 3000,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,11 @@ async function bootstrap() {
 
 	app.useGlobalInterceptors(new LoggingInterceptor());
 
+	app.enableCors({
+		origin: true,
+		credentials: true,
+	});
+
 	app.enableShutdownHooks();
 
 	await app.startAllMicroservices();

--- a/src/modules/accounts/services/accounts.service.spec.ts
+++ b/src/modules/accounts/services/accounts.service.spec.ts
@@ -3,6 +3,7 @@ import { NotFoundException, ConflictException, Logger } from '@nestjs/common';
 import { of, throwError } from 'rxjs';
 import { AccountsService } from './accounts.service';
 import { UserRepository } from '../../common/repositories';
+import { SearchIndexService } from '../../cache/search-index.service';
 import { User } from '../../common/entities/user.entity';
 
 const mockUser = (): User =>
@@ -42,6 +43,12 @@ describe('AccountsService', () => {
 				{
 					provide: 'EVENTS_SERVICE',
 					useValue: eventsClient,
+				},
+				{
+					provide: SearchIndexService,
+					useValue: {
+						indexUser: jest.fn().mockResolvedValue(undefined),
+					},
 				},
 			],
 		}).compile();

--- a/src/modules/accounts/services/accounts.service.ts
+++ b/src/modules/accounts/services/accounts.service.ts
@@ -5,6 +5,7 @@ import { User } from '../../common/entities/user.entity';
 import { UserRegisteredEvent } from '../../shared/events';
 import { UserRepository } from '../../common/repositories';
 import { UserCreatedEvent } from '../events';
+import { SearchIndexService } from '../../cache/search-index.service';
 
 /**
  * AccountsService - Manages core user identity and lifecycle
@@ -22,7 +23,8 @@ export class AccountsService {
 	constructor(
 		private readonly userRepository: UserRepository,
 		@Inject('EVENTS_SERVICE')
-		private readonly eventsClient: ClientProxy
+		private readonly eventsClient: ClientProxy,
+		private readonly searchIndexService: SearchIndexService
 	) {}
 
 	private async findOne(id: string): Promise<User> {
@@ -39,9 +41,6 @@ export class AccountsService {
 	 * Create a minimal user record from event
 	 * Used when receiving user.registered event from auth module
 	 * Only creates the record with id and phoneNumber, other fields can be filled later
-	 *
-	 * NOTE: Search index is NOT created at this stage.
-	 * User becomes searchable only after ProfileService.completeProfile() is called.
 	 */
 	public async createFromEvent(event: UserRegisteredEvent): Promise<User> {
 		const existingUser = await this.userRepository.findById(event.userId);
@@ -61,6 +60,9 @@ export class AccountsService {
 			phoneNumber: event.phoneNumber,
 			isActive: true,
 		});
+
+		// Index user in search cache
+		await this.searchIndexService.indexUser(user);
 
 		// Publish user.created event for projections
 		this.logger.log(`Emitting user.created for userId=${user.id}`);

--- a/src/modules/cache/cache.service.ts
+++ b/src/modules/cache/cache.service.ts
@@ -54,6 +54,15 @@ export class CacheService {
 		}
 	}
 
+	async hget(key: string, field: string): Promise<string | null> {
+		try {
+			return await this.redis.hget(key, field);
+		} catch (error) {
+			this.logger.error(`Failed to hget ${key} ${field}:`, error);
+			return null;
+		}
+	}
+
 	async exists(key: string): Promise<boolean> {
 		try {
 			const result = await this.redis.exists(key);

--- a/src/modules/cache/cache.service.ts
+++ b/src/modules/cache/cache.service.ts
@@ -35,6 +35,15 @@ export class CacheService {
 		}
 	}
 
+	async hget(key: string, field: string): Promise<string | null> {
+		try {
+			return await this.redis.hget(key, field);
+		} catch (error) {
+			this.logger.error(`Failed to hget field ${field} from ${key}:`, error);
+			return null;
+		}
+	}
+
 	async del(key: string): Promise<void> {
 		try {
 			await this.redis.del(key);

--- a/src/modules/cache/cache.service.ts
+++ b/src/modules/cache/cache.service.ts
@@ -63,15 +63,6 @@ export class CacheService {
 		}
 	}
 
-	async hget(key: string, field: string): Promise<string | null> {
-		try {
-			return await this.redis.hget(key, field);
-		} catch (error) {
-			this.logger.error(`Failed to hget ${key} ${field}:`, error);
-			return null;
-		}
-	}
-
 	async exists(key: string): Promise<boolean> {
 		try {
 			const result = await this.redis.exists(key);

--- a/src/modules/cache/search-index.service.spec.ts
+++ b/src/modules/cache/search-index.service.spec.ts
@@ -5,6 +5,7 @@ import { User } from '../common/entities/user.entity';
 const mockCacheService = {
 	pipeline: jest.fn(),
 	get: jest.fn(),
+	hget: jest.fn(),
 	keys: jest.fn(),
 	zrange: jest.fn(),
 	delMany: jest.fn(),
@@ -82,16 +83,16 @@ describe('SearchIndexService', () => {
 
 	describe('searchByPhoneNumber', () => {
 		it('should return userId from cache', async () => {
-			mockCacheService.get = jest.fn().mockResolvedValue('user-1');
+			mockCacheService.hget = jest.fn().mockResolvedValue('user-1');
 
 			const result = await service.searchByPhoneNumber('+1234567890');
 
-			expect(mockCacheService.get).toHaveBeenCalledWith('search:phone:+1234567890');
+			expect(mockCacheService.hget).toHaveBeenCalledWith('search:phone', '+1234567890');
 			expect(result).toBe('user-1');
 		});
 
 		it('should return null when cache throws', async () => {
-			mockCacheService.get = jest.fn().mockRejectedValue(new Error('Redis error'));
+			mockCacheService.hget = jest.fn().mockRejectedValue(new Error('Redis error'));
 
 			const result = await service.searchByPhoneNumber('+1234567890');
 
@@ -101,16 +102,16 @@ describe('SearchIndexService', () => {
 
 	describe('searchByUsername', () => {
 		it('should return userId from cache (lowercased key)', async () => {
-			mockCacheService.get = jest.fn().mockResolvedValue('user-1');
+			mockCacheService.hget = jest.fn().mockResolvedValue('user-1');
 
 			const result = await service.searchByUsername('Alice');
 
-			expect(mockCacheService.get).toHaveBeenCalledWith('search:username:alice');
+			expect(mockCacheService.hget).toHaveBeenCalledWith('search:username', 'alice');
 			expect(result).toBe('user-1');
 		});
 
 		it('should return null when cache throws', async () => {
-			mockCacheService.get = jest.fn().mockRejectedValue(new Error('Redis error'));
+			mockCacheService.hget = jest.fn().mockRejectedValue(new Error('Redis error'));
 
 			const result = await service.searchByUsername('Alice');
 

--- a/src/modules/cache/search-index.service.ts
+++ b/src/modules/cache/search-index.service.ts
@@ -87,7 +87,7 @@ export class SearchIndexService {
 
 	async searchByPhoneNumber(phoneNumber: string): Promise<string | null> {
 		try {
-			return await this.cacheService.get<string>(`${this.PHONE_INDEX_KEY}:${phoneNumber}`);
+			return await this.cacheService.hget(this.PHONE_INDEX_KEY, phoneNumber);
 		} catch (error) {
 			this.logger.error(`Failed to search by phone number ${phoneNumber}:`, error);
 			return null;
@@ -96,9 +96,7 @@ export class SearchIndexService {
 
 	async searchByUsername(username: string): Promise<string | null> {
 		try {
-			return await this.cacheService.get<string>(
-				`${this.USERNAME_INDEX_KEY}:${username.toLowerCase()}`
-			);
+			return await this.cacheService.hget(this.USERNAME_INDEX_KEY, username.toLowerCase());
 		} catch (error) {
 			this.logger.error(`Failed to search by username ${username}:`, error);
 			return null;

--- a/src/modules/common/repositories/user.repository.ts
+++ b/src/modules/common/repositories/user.repository.ts
@@ -124,6 +124,21 @@ export class UserRepository {
 	}
 
 	/**
+	 * Search users by display name (first name, last name, or full name)
+	 */
+	async searchByDisplayName(query: string, limit: number = 20): Promise<User[]> {
+		const pattern = `%${query}%`;
+		return this.repository.find({
+			where: [
+				{ firstName: ILike(pattern), isActive: true },
+				{ lastName: ILike(pattern), isActive: true },
+			],
+			take: limit,
+			order: { createdAt: 'DESC' },
+		});
+	}
+
+	/**
 	 * Update user's last seen timestamp
 	 */
 	async updateLastSeen(id: string, lastSeen: Date = new Date()): Promise<void> {

--- a/src/modules/profile/services/profile.service.spec.ts
+++ b/src/modules/profile/services/profile.service.spec.ts
@@ -3,6 +3,7 @@ import { NotFoundException, ConflictException, BadRequestException } from '@nest
 import { ProfileService } from './profile.service';
 import { UserRepository } from '../../common/repositories';
 import { MediaClientService, MediaMetadata } from './media-client.service';
+import { SearchIndexService } from '../../cache/search-index.service';
 import { User } from '../../common/entities/user.entity';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
 
@@ -52,6 +53,12 @@ describe('ProfileService', () => {
 					provide: MediaClientService,
 					useValue: {
 						getMediaMetadata: jest.fn(),
+					},
+				},
+				{
+					provide: SearchIndexService,
+					useValue: {
+						indexUser: jest.fn().mockResolvedValue(undefined),
 					},
 				},
 			],

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -1,14 +1,18 @@
-import { Injectable, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
 import { User } from '../../common/entities/user.entity';
 import { UserRepository } from '../../common/repositories';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
 import { MediaClientService } from './media-client.service';
+import { SearchIndexService } from '../../cache/search-index.service';
 
 @Injectable()
 export class ProfileService {
+	private readonly logger = new Logger(ProfileService.name);
+
 	constructor(
 		private readonly userRepository: UserRepository,
-		private readonly mediaClient: MediaClientService
+		private readonly mediaClient: MediaClientService,
+		private readonly searchIndexService: SearchIndexService
 	) {}
 
 	private async findOne(id: string): Promise<User> {
@@ -56,6 +60,16 @@ export class ProfileService {
 		const { avatarMediaId, ...fields } = dto;
 		Object.assign(user, fields);
 
-		return this.userRepository.save(user);
+		const saved = await this.userRepository.save(user);
+
+		if (saved.username && saved.firstName) {
+			try {
+				await this.searchIndexService.indexUser(saved);
+			} catch (err) {
+				this.logger.warn(`Failed to index user ${saved.id} in search: ${err}`);
+			}
+		}
+
+		return saved;
 	}
 }

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import {
+	Injectable,
+	Logger,
+	NotFoundException,
+	ConflictException,
+	BadRequestException,
+} from '@nestjs/common';
 import { User } from '../../common/entities/user.entity';
 import { UserRepository } from '../../common/repositories';
 import { UpdateProfileDto } from '../dto/update-profile.dto';

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -68,7 +68,7 @@ export class ProfileService {
 
 		const saved = await this.userRepository.save(user);
 
-		if (saved.username && saved.firstName) {
+		if (saved.username || saved.firstName) {
 			try {
 				await this.searchIndexService.indexUser(saved);
 			} catch (err) {

--- a/src/modules/search/controllers/user-search.controller.ts
+++ b/src/modules/search/controllers/user-search.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Query, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Query, Body, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiQuery, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { UserSearchService, UserSearchResult } from '../services/user-search.service';
 import { User } from '../../common/entities/user.entity';
+import { BatchPhoneSearchDto } from '../dto/batch-phone-search.dto';
 
 @ApiTags('Search')
 @ApiBearerAuth()
@@ -16,6 +17,14 @@ export class UserSearchController {
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async searchByPhone(@Query('phoneNumber') phoneNumber: string): Promise<User | null> {
 		return this.userSearchService.searchByPhone(phoneNumber);
+	}
+
+	@Post('phone/batch')
+	@ApiOperation({ summary: 'Search users by phone numbers in batch' })
+	@ApiResponse({ status: HttpStatus.OK, description: 'List of matched users' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
+	async searchByPhoneBatch(@Body() dto: BatchPhoneSearchDto): Promise<User[]> {
+		return this.userSearchService.searchByPhoneBatch(dto.phoneNumbers);
 	}
 
 	@Get('username')

--- a/src/modules/search/dto/batch-phone-search.dto.ts
+++ b/src/modules/search/dto/batch-phone-search.dto.ts
@@ -1,0 +1,14 @@
+import { IsArray, IsString, ArrayMaxSize } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BatchPhoneSearchDto {
+	@ApiProperty({
+		description: 'Array of E.164 phone numbers to search',
+		type: [String],
+		maxItems: 1000,
+	})
+	@IsArray()
+	@IsString({ each: true })
+	@ArrayMaxSize(1000)
+	phoneNumbers: string[];
+}

--- a/src/modules/search/services/user-search.service.spec.ts
+++ b/src/modules/search/services/user-search.service.spec.ts
@@ -86,6 +86,9 @@ describe('UserSearchService', () => {
 					provide: UserRepository,
 					useValue: {
 						findById: jest.fn(),
+						findByPhoneNumber: jest.fn(),
+						findByUsernameInsensitive: jest.fn(),
+						searchByDisplayName: jest.fn(),
 					},
 				},
 			],
@@ -97,8 +100,10 @@ describe('UserSearchService', () => {
 		userRepository = module.get(UserRepository);
 	});
 
+	/* --- PLACEHOLDER_TESTS --- */
+
 	describe('searchByPhone', () => {
-		it('returns user when found and searchByPhone is enabled', async () => {
+		it('returns user when found in Redis index', async () => {
 			const user = mockUser();
 			searchIndexService.searchByPhoneNumber.mockResolvedValue('uuid-1');
 			privacyService.getSettings.mockResolvedValue(mockPrivacySettings({ searchByPhone: true }));
@@ -109,6 +114,20 @@ describe('UserSearchService', () => {
 			expect(result).toBe(user);
 		});
 
+		it('falls back to database when not in Redis', async () => {
+			const user = mockUser();
+			searchIndexService.searchByPhoneNumber.mockResolvedValue(null);
+			userRepository.findByPhoneNumber.mockResolvedValue(user);
+			privacyService.getSettings.mockResolvedValue(mockPrivacySettings({ searchByPhone: true }));
+			userRepository.findById.mockResolvedValue(user);
+			searchIndexService.indexUser.mockResolvedValue(undefined);
+
+			const result = await service.searchByPhone('+33600000001');
+
+			expect(result).toBe(user);
+			expect(userRepository.findByPhoneNumber).toHaveBeenCalledWith('+33600000001');
+		});
+
 		it('returns null when user has disabled searchByPhone', async () => {
 			searchIndexService.searchByPhoneNumber.mockResolvedValue('uuid-1');
 			privacyService.getSettings.mockResolvedValue(mockPrivacySettings({ searchByPhone: false }));
@@ -116,21 +135,20 @@ describe('UserSearchService', () => {
 			const result = await service.searchByPhone('+33600000001');
 
 			expect(result).toBeNull();
-			expect(userRepository.findById).not.toHaveBeenCalled();
 		});
 
-		it('returns null when phone number is not indexed', async () => {
+		it('returns null when not found in Redis or database', async () => {
 			searchIndexService.searchByPhoneNumber.mockResolvedValue(null);
+			userRepository.findByPhoneNumber.mockResolvedValue(null);
 
 			const result = await service.searchByPhone('+33600000001');
 
 			expect(result).toBeNull();
-			expect(privacyService.getSettings).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('searchByUsername', () => {
-		it('returns user when found and searchByUsername is enabled', async () => {
+		it('returns user when found in Redis index', async () => {
 			const user = mockUser();
 			searchIndexService.searchByUsername.mockResolvedValue('uuid-1');
 			privacyService.getSettings.mockResolvedValue(mockPrivacySettings({ searchByUsername: true }));
@@ -141,6 +159,20 @@ describe('UserSearchService', () => {
 			expect(result).toBe(user);
 		});
 
+		it('falls back to database when not in Redis', async () => {
+			const user = mockUser();
+			searchIndexService.searchByUsername.mockResolvedValue(null);
+			userRepository.findByUsernameInsensitive.mockResolvedValue(user);
+			privacyService.getSettings.mockResolvedValue(mockPrivacySettings({ searchByUsername: true }));
+			userRepository.findById.mockResolvedValue(user);
+			searchIndexService.indexUser.mockResolvedValue(undefined);
+
+			const result = await service.searchByUsername('testuser');
+
+			expect(result).toBe(user);
+			expect(userRepository.findByUsernameInsensitive).toHaveBeenCalledWith('testuser');
+		});
+
 		it('returns null when user has disabled searchByUsername', async () => {
 			searchIndexService.searchByUsername.mockResolvedValue('uuid-1');
 			privacyService.getSettings.mockResolvedValue(mockPrivacySettings({ searchByUsername: false }));
@@ -148,16 +180,15 @@ describe('UserSearchService', () => {
 			const result = await service.searchByUsername('testuser');
 
 			expect(result).toBeNull();
-			expect(userRepository.findById).not.toHaveBeenCalled();
 		});
 
-		it('returns null when username is not indexed', async () => {
+		it('returns null when not found in Redis or database', async () => {
 			searchIndexService.searchByUsername.mockResolvedValue(null);
+			userRepository.findByUsernameInsensitive.mockResolvedValue(null);
 
 			const result = await service.searchByUsername('testuser');
 
 			expect(result).toBeNull();
-			expect(privacyService.getSettings).not.toHaveBeenCalled();
 		});
 	});
 
@@ -178,6 +209,25 @@ describe('UserSearchService', () => {
 			});
 		});
 
+		it('falls back to database when Redis returns empty', async () => {
+			const user = mockUser();
+			searchIndexService.searchByName.mockResolvedValue([]);
+			searchIndexService.getCachedUser.mockResolvedValue(null);
+			userRepository.searchByDisplayName.mockResolvedValue([user]);
+			searchIndexService.indexUser.mockResolvedValue(undefined);
+
+			const result = await service.searchByDisplayName('Test');
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({
+				userId: 'uuid-1',
+				username: 'testuser',
+				firstName: 'Test',
+				lastName: 'User',
+			});
+			expect(userRepository.searchByDisplayName).toHaveBeenCalledWith('Test', 20);
+		});
+
 		it('skips users not found in cache', async () => {
 			searchIndexService.searchByName.mockResolvedValue(['uuid-1', 'uuid-2']);
 			searchIndexService.getCachedUser
@@ -189,8 +239,10 @@ describe('UserSearchService', () => {
 			expect(result).toHaveLength(1);
 		});
 
-		it('returns empty array when no users match', async () => {
+		it('returns empty array when no users match anywhere', async () => {
 			searchIndexService.searchByName.mockResolvedValue([]);
+			searchIndexService.getCachedUser.mockResolvedValue(null);
+			userRepository.searchByDisplayName.mockResolvedValue([]);
 
 			const result = await service.searchByDisplayName('NoMatch');
 

--- a/src/modules/search/services/user-search.service.ts
+++ b/src/modules/search/services/user-search.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { SearchIndexService, SearchIndexEntry } from '../../cache/search-index.service';
 import { PrivacyService } from '../../privacy/services/privacy.service';
 import { UserRepository } from '../../common/repositories';
@@ -13,6 +13,8 @@ export interface UserSearchResult {
 
 @Injectable()
 export class UserSearchService {
+	private readonly logger = new Logger(UserSearchService.name);
+
 	constructor(
 		private readonly searchIndexService: SearchIndexService,
 		private readonly privacyService: PrivacyService,
@@ -20,9 +22,18 @@ export class UserSearchService {
 	) {}
 
 	async searchByPhone(phoneNumber: string): Promise<User | null> {
-		const userId = await this.searchIndexService.searchByPhoneNumber(phoneNumber);
+		// Try Redis index first
+		let userId = await this.searchIndexService.searchByPhoneNumber(phoneNumber);
+
+		// Fallback to database if not in Redis
 		if (!userId) {
-			return null;
+			const user = await this.userRepository.findByPhoneNumber(phoneNumber);
+			if (!user) {
+				return null;
+			}
+			userId = user.id;
+			// Re-index for next time
+			this.reindexUser(user);
 		}
 
 		const privacy = await this.privacyService.getSettings(userId);
@@ -34,9 +45,18 @@ export class UserSearchService {
 	}
 
 	async searchByUsername(username: string): Promise<User | null> {
-		const userId = await this.searchIndexService.searchByUsername(username);
+		// Try Redis index first
+		let userId = await this.searchIndexService.searchByUsername(username);
+
+		// Fallback to database if not in Redis
 		if (!userId) {
-			return null;
+			const user = await this.userRepository.findByUsernameInsensitive(username);
+			if (!user) {
+				return null;
+			}
+			userId = user.id;
+			// Re-index for next time
+			this.reindexUser(user);
 		}
 
 		const privacy = await this.privacyService.getSettings(userId);
@@ -63,6 +83,21 @@ export class UserSearchService {
 			}
 		}
 
+		// Fallback to database if Redis returned no results
+		if (results.length === 0) {
+			const dbResults = await this.userRepository.searchByDisplayName(query, limit);
+			for (const user of dbResults) {
+				results.push({
+					userId: user.id,
+					username: user.username,
+					firstName: user.firstName,
+					lastName: user.lastName,
+				});
+				// Re-index for next time
+				this.reindexUser(user);
+			}
+		}
+
 		return results;
 	}
 
@@ -72,5 +107,13 @@ export class UserSearchService {
 			throw new NotFoundException('User not found');
 		}
 		await this.searchIndexService.indexUser(user);
+	}
+
+	private reindexUser(user: User): void {
+		if (user.username && user.firstName) {
+			this.searchIndexService.indexUser(user).catch((err) => {
+				this.logger.warn(`Failed to re-index user ${user.id}: ${err}`);
+			});
+		}
 	}
 }

--- a/src/modules/search/services/user-search.service.ts
+++ b/src/modules/search/services/user-search.service.ts
@@ -101,6 +101,19 @@ export class UserSearchService {
 		return results;
 	}
 
+	async searchByPhoneBatch(phoneNumbers: string[]): Promise<User[]> {
+		const results: User[] = [];
+
+		for (const phoneNumber of phoneNumbers) {
+			const user = await this.searchByPhone(phoneNumber);
+			if (user) {
+				results.push(user);
+			}
+		}
+
+		return results;
+	}
+
 	async indexUser(userId: string): Promise<void> {
 		const user = await this.userRepository.findById(userId);
 		if (!user) {


### PR DESCRIPTION
Cherry-pick safe fixes from deploy/preprod. No /v1 routing changes.

**Commits (8/8):**
1. fix(docker): healthcheck for distroless and correct port/path
2. fix(profile): index user in search after profile update
3. style(profile): fix prettier formatting
4. fix(search): use HGET for Redis hash lookups and add DB fallback
5. feat(cors): enable CORS for cross-origin requests
6. fix(search): use HGET for Redis search + index users on profile update
7. fix(cache): remove duplicate hget method
8. feat(search): add batch phone search endpoint

**Verification:** `git diff main..HEAD -- src/main.ts` shows only CORS enablement. No enableVersioning, globalPrefix, or /v1 routing changes.