### PR TITLE
fix(accounts,profile): remove duplicate constructor param and align test URLs

### DIFF
--- a/src/modules/accounts/services/accounts.service.spec.ts
+++ b/src/modules/accounts/services/accounts.service.spec.ts
@@ -111,7 +111,7 @@ describe('AccountsService', () => {
 			userRepository.findById.mockResolvedValue(null);
 			userRepository.findByPhoneNumber.mockResolvedValue(null);
 			userRepository.create.mockResolvedValue(created);
-			searchIndexService.indexUser.mockRejectedValue(new Error('Redis down'));
+			searchIndexService.indexUser.mockRejectedValueOnce(new Error('Redis down'));
 
 			const result = await service.createFromEvent(event);
 

--- a/src/modules/accounts/services/accounts.service.ts
+++ b/src/modules/accounts/services/accounts.service.ts
@@ -24,8 +24,7 @@ export class AccountsService {
 		private readonly userRepository: UserRepository,
 		private readonly searchIndexService: SearchIndexService,
 		@Inject('EVENTS_SERVICE')
-		private readonly eventsClient: ClientProxy,
-		private readonly searchIndexService: SearchIndexService
+		private readonly eventsClient: ClientProxy
 	) {}
 
 	private async findOne(id: string): Promise<User> {

--- a/src/modules/profile/services/media-client.service.spec.ts
+++ b/src/modules/profile/services/media-client.service.spec.ts
@@ -58,7 +58,7 @@ describe('MediaClientService', () => {
 
 			expect(result).toEqual(validBody);
 			expect(mockFetch).toHaveBeenCalledWith(
-				'http://media-service:3000/media/v1/media-1',
+				'http://media-service:3000/media/media-1',
 				expect.objectContaining({
 					method: 'GET',
 					headers: { 'x-user-id': 'user-1', Accept: 'application/json' },


### PR DESCRIPTION
## Summary
- Remove duplicate `searchIndexService` constructor parameter in `AccountsService` (squash merge artifact from PR #58)
- Fix `media-client.service.spec.ts` to expect `/media/` instead of `/media/v1/` (aligned with the `/v1/` removal)
- Use `mockRejectedValueOnce` instead of `mockRejectedValue` in accounts test

## Test plan
- [x] All 312 unit tests pass
- [x] ESLint clean
