### PR TITLE
fix(accounts): align UserRegisteredEvent field with auth-service contract

### DIFF
--- a/src/modules/accounts/services/accounts.service.spec.ts
+++ b/src/modules/accounts/services/accounts.service.spec.ts
@@ -60,7 +60,7 @@ describe('AccountsService', () => {
 	});
 
 	describe('createFromEvent', () => {
-		const event = { userId: 'uuid-1', phoneNumber: '+33600000001', registeredAt: new Date() };
+		const event = { userId: 'uuid-1', phoneNumber: '+33600000001', timestamp: new Date() };
 
 		it('returns existing user if already present', async () => {
 			const existing = mockUser();

--- a/src/modules/shared/events/user-registered.event.ts
+++ b/src/modules/shared/events/user-registered.event.ts
@@ -4,6 +4,6 @@ export class UserRegisteredEvent {
 	constructor(
 		public readonly userId: string,
 		public readonly phoneNumber: string,
-		public readonly registeredAt: Date = new Date()
+		public readonly timestamp: Date = new Date()
 	) {}
 }


### PR DESCRIPTION
## Summary
- Renamed `registeredAt` to `timestamp` in `UserRegisteredEvent` class to match the auth-service's event interface (`timestamp: Date`)
- Updated test to use the corrected field name

**Note:** The `@MessagePattern` -> `@EventPattern` fix was already applied on `main`. This PR addresses the remaining field name mismatch between auth-service (emitter) and user-service (consumer).

## Test plan
- [x] Unit tests updated for field name change
- [ ] Verify user.registered events are received after deploy