### PR TITLE
fix(ci): run docker e2e without TTY

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"test:cov": "jest --coverage",
 		"test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
 		"test:e2e": "jest --config ./test/jest-e2e.json",
-		"test:e2e:docker": "docker compose -f docker/test/compose.yml run --rm --build test-runner",
+		"test:e2e:docker": "docker compose -f docker/test/compose.yml run -T --rm --build test-runner",
 		"test:e2e:docker:cleanup": "docker compose -f docker/test/compose.yml down -v",
 		"typeorm": "typeorm-ts-node-commonjs",
 		"migration:generate": "npm run typeorm -- migration:generate -d src/config/database.config.ts",

--- a/src/docker/health-check.spec.ts
+++ b/src/docker/health-check.spec.ts
@@ -153,7 +153,7 @@ describe('health-check', () => {
 		loadHealthCheck();
 
 		expect(mockConsoleLog).toHaveBeenCalledWith(
-			expect.stringContaining('Target: GET http://localhost:3001/health/ready')
+			expect.stringContaining('Target: GET http://localhost:3011/user/v1/health/ready')
 		);
 		expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Timeout: 3000ms'));
 	});


### PR DESCRIPTION
## Summary
- Remove TTY requirement from docker e2e invocation so the pre-push hook works in non-interactive environments (CI, some shells)
- Align health-check spec log expectation with the updated output

## Test plan
- [ ] Unit tests green
- [ ] Pre-push hook runs end-to-end without TTY

Authored by @DALM1-TT (2026-04-09).