### PR TITLE
[WHISPR-765] (Accounts) Avoid double-indexing user on createFromEvent

### DIFF
--- a/src/modules/accounts/services/accounts.service.spec.ts
+++ b/src/modules/accounts/services/accounts.service.spec.ts
@@ -95,7 +95,7 @@ describe('AccountsService', () => {
 			expect(result).toBe(created);
 		});
 
-		it('indexes user in search cache after creation', async () => {
+		it('indexes user exactly once in search cache after creation', async () => {
 			const created = mockUser();
 			userRepository.findById.mockResolvedValue(null);
 			userRepository.findByPhoneNumber.mockResolvedValue(null);
@@ -103,6 +103,7 @@ describe('AccountsService', () => {
 
 			await service.createFromEvent(event);
 
+			expect(searchIndexService.indexUser).toHaveBeenCalledTimes(1);
 			expect(searchIndexService.indexUser).toHaveBeenCalledWith(created);
 		});
 

--- a/src/modules/accounts/services/accounts.service.ts
+++ b/src/modules/accounts/services/accounts.service.ts
@@ -95,8 +95,6 @@ export class AccountsService {
 			}
 		}
 
-		await this.searchIndexService.indexUser(user);
-
 		return user;
 	}
 


### PR DESCRIPTION
## Summary

- Remove duplicate `searchIndexService.indexUser(user)` call in `AccountsService.createFromEvent` — the second call lived outside the try/catch, bypassing the "Redis failure must not abort account creation" guarantee and causing a redundant Redis pipeline write per account creation.
- Strengthen `accounts.service.spec.ts` to assert `indexUser` is called **exactly once** (the previous assertion passed with either 1 or 2 calls).

## Context

While reviewing PR #72 (deploy/preprod reconciliation), I found that the ops-related items it was shipping (distroless healthcheck explicit node binary, `/user/v1/health/ready` path, `HTTP_PORT` env var, `swagger.ts` relative `/` host, `EventPattern` for `user.registered`) are **already present on `main`**. The only regression still worth fixing is this duplicate `indexUser` call, which predates that PR.

## Test plan

- [x] Unit tests green (`npx jest --testPathPatterns="accounts" --no-coverage`)
- [x] Lint clean on touched files
- [x] Full suite green (317 tests)

Closes WHISPR-765