### PR TITLE
[WHISPR-768] Migrate Sonar analysis to SonarCloud for free OSS analysis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,17 +128,16 @@ jobs:
       ####################################################################################################
       # SonarCloud Analysis (all branches — enables PR decoration and quality gate enforcement)
       ####################################################################################################
-      - name: Check SonarCloud secrets
+      - name: Check SonarCloud token
         id: check-secrets
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         run: |
-          if [[ -n "$SONAR_TOKEN" && -n "$SONAR_HOST_URL" ]]; then
+          if [[ -n "$SONAR_TOKEN" ]]; then
             echo "secrets-available=true" >> $GITHUB_OUTPUT
           else
             echo "secrets-available=false" >> $GITHUB_OUTPUT
-            echo "⚠️ SonarCloud secrets not configured. Skipping SonarCloud analysis."
+            echo "⚠️ SONAR_TOKEN not configured. Skipping SonarCloud analysis."
           fi
 
       - name: SonarCloud Analysis
@@ -147,7 +146,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_HOST_URL: https://sonarcloud.io
 
       - name: SonarCloud Quality Gate
         if: ${{ steps.check-secrets.outputs.secrets-available == 'true' }}
@@ -155,7 +154,7 @@ jobs:
         timeout-minutes: 5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_HOST_URL: https://sonarcloud.io
 
       # - name: Upload coverage to Codecov
       #   uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,33 +126,36 @@ jobs:
           HTTP_PORT: 3000
 
       ####################################################################################################
-      # SonarQube Analysis (conditional on should_deploy and secrets availability)
+      # SonarCloud Analysis (all branches — enables PR decoration and quality gate enforcement)
       ####################################################################################################
-      # - name: Check SonarQube secrets
-      #   id: check-secrets
-      #   run: |
-      #     if [[ -n "${{ secrets.SONAR_TOKEN }}" && -n "${{ secrets.SONAR_HOST_URL }}" ]]; then
-      #       echo "secrets-available=true" >> $GITHUB_OUTPUT
-      #     else
-      #       echo "secrets-available=false" >> $GITHUB_OUTPUT
-      #       echo "⚠️ SonarQube secrets not configured. Skipping SonarQube analysis."
-      #     fi
+      - name: Check SonarCloud secrets
+        id: check-secrets
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: |
+          if [[ -n "$SONAR_TOKEN" && -n "$SONAR_HOST_URL" ]]; then
+            echo "secrets-available=true" >> $GITHUB_OUTPUT
+          else
+            echo "secrets-available=false" >> $GITHUB_OUTPUT
+            echo "⚠️ SonarCloud secrets not configured. Skipping SonarCloud analysis."
+          fi
 
-      # - name: SonarQube Analysis
-      #   if: ${{ inputs.should_deploy == 'true' && steps.check-secrets.outputs.secrets-available == 'true' }}
-      #   uses: sonarsource/sonarqube-scan-action@v6.0.0
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      - name: SonarCloud Analysis
+        if: ${{ steps.check-secrets.outputs.secrets-available == 'true' }}
+        uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
-      # - name: SonarQube Quality Gate
-      #   if: ${{ inputs.should_deploy == 'true' && steps.check-secrets.outputs.secrets-available == 'true' }}
-      #   uses: sonarsource/sonarqube-quality-gate-action@v1.2.0
-      #   timeout-minutes: 5
-      #   env:
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      - name: SonarCloud Quality Gate
+        if: ${{ steps.check-secrets.outputs.secrets-available == 'true' }}
+        uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       # - name: Upload coverage to Codecov
       #   uses: codecov/codecov-action@v3

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,8 @@
-# SonarQube project configuration
+# SonarCloud project configuration
+sonar.organization=whispr-messenger
 sonar.projectKey=whispr-messenger_user-service
 sonar.projectName=User Service
 sonar.projectDescription=User management service for Whispr application
-sonar.host.url=https://sonarqube.whispr.epitech-msc2026.me
 
 # Source and test directories
 sonar.sources=src


### PR DESCRIPTION
## Summary

- Point `sonar-project.properties` at the SonarCloud organization (`whispr-messenger`) and drop the dead self-hosted `sonar.host.url`
- Uncomment the `Check SonarCloud secrets`, `SonarCloud Analysis` and `SonarCloud Quality Gate` steps in `tests.yml` with SHA-pinned actions (v6.0.0 / v1.2.0)
- Remove the `inputs.should_deploy == 'true'` gate so the scan runs on every PR (enables PR decoration)

## Why

The self-hosted SonarQube instance was removed in WHISPR-509, and the Sonar steps for `user-service` were left commented out. Coverage was generated (`coverage/lcov.info`) but never uploaded, the quality gate never evaluated, and PRs merged blind. This replicates the migration already done on `auth-service` in WHISPR-441 (PR whispr-messenger/auth-service#91).

## Test plan

- [ ] CI is green on this PR
- [ ] SonarCloud analysis step runs (requires `SONAR_TOKEN` + `SONAR_HOST_URL=https://sonarcloud.io` repo secrets)
- [ ] Coverage from `coverage/lcov.info` appears on the SonarCloud dashboard for `whispr-messenger_user-service`
- [ ] Quality gate result decorates the PR

## References

- WHISPR-441 — auth-service migration (reference diff)
- WHISPR-509 — self-hosted SonarQube removal
- WHISPR-490 — quality gate enforcement context

Closes WHISPR-768