### PR TITLE
[WHISPR-766] Cover searchByPhoneBatch edge cases

### DIFF
--- a/src/modules/search/services/user-search.service.spec.ts
+++ b/src/modules/search/services/user-search.service.spec.ts
@@ -249,6 +249,94 @@ describe('UserSearchService', () => {
 		});
 	});
 
+	describe('searchByPhoneBatch', () => {
+		it('returns empty array for empty input', async () => {
+			const result = await service.searchByPhoneBatch([]);
+
+			expect(result).toEqual([]);
+			expect(searchIndexService.searchByPhoneNumber).not.toHaveBeenCalled();
+		});
+
+		it('returns matched users for multiple phone numbers', async () => {
+			const userA = { ...mockUser(), id: 'uuid-a', phoneNumber: '+33600000001' } as User;
+			const userB = { ...mockUser(), id: 'uuid-b', phoneNumber: '+33600000002' } as User;
+
+			searchIndexService.searchByPhoneNumber.mockImplementation(async (n) =>
+				n === '+33600000001' ? 'uuid-a' : n === '+33600000002' ? 'uuid-b' : null
+			);
+			privacyService.getSettings.mockResolvedValue(mockPrivacySettings({ searchByPhone: true }));
+			userRepository.findById.mockImplementation(async (id) =>
+				id === 'uuid-a' ? userA : id === 'uuid-b' ? userB : null
+			);
+
+			const result = await service.searchByPhoneBatch(['+33600000001', '+33600000002']);
+
+			expect(result).toHaveLength(2);
+			expect(result).toEqual(expect.arrayContaining([userA, userB]));
+		});
+
+		it('filters out numbers with no match', async () => {
+			const userA = { ...mockUser(), id: 'uuid-a' } as User;
+			searchIndexService.searchByPhoneNumber.mockImplementation(async (n) =>
+				n === '+33600000001' ? 'uuid-a' : null
+			);
+			userRepository.findByPhoneNumberWithFilter.mockResolvedValue(null);
+			privacyService.getSettings.mockResolvedValue(mockPrivacySettings({ searchByPhone: true }));
+			userRepository.findById.mockResolvedValue(userA);
+
+			const result = await service.searchByPhoneBatch(['+33600000001', '+33699999999']);
+
+			expect(result).toEqual([userA]);
+		});
+
+		it('filters out users with searchByPhone disabled', async () => {
+			const userA = { ...mockUser(), id: 'uuid-a' } as User;
+			const userB = { ...mockUser(), id: 'uuid-b' } as User;
+
+			searchIndexService.searchByPhoneNumber.mockImplementation(async (n) =>
+				n === '+33600000001' ? 'uuid-a' : 'uuid-b'
+			);
+			privacyService.getSettings.mockImplementation(async (id) =>
+				mockPrivacySettings({ searchByPhone: id === 'uuid-a' })
+			);
+			userRepository.findById.mockImplementation(async (id) => (id === 'uuid-a' ? userA : userB));
+
+			const result = await service.searchByPhoneBatch(['+33600000001', '+33600000002']);
+
+			expect(result).toEqual([userA]);
+		});
+
+		it('tolerates individual failures without aborting the batch', async () => {
+			const userB = { ...mockUser(), id: 'uuid-b' } as User;
+
+			searchIndexService.searchByPhoneNumber.mockImplementation(async (n) => {
+				if (n === '+33600000001') throw new Error('Redis error');
+				return 'uuid-b';
+			});
+			privacyService.getSettings.mockResolvedValue(mockPrivacySettings({ searchByPhone: true }));
+			userRepository.findById.mockResolvedValue(userB);
+			userRepository.findByPhoneNumberWithFilter.mockResolvedValue(null);
+
+			const result = await service.searchByPhoneBatch(['+33600000001', '+33600000002']);
+
+			expect(result).toEqual([userB]);
+		});
+
+		it('processes more than 50 numbers via chunking', async () => {
+			const phoneNumbers = Array.from(
+				{ length: 120 },
+				(_, i) => `+3360000${String(i).padStart(4, '0')}`
+			);
+			searchIndexService.searchByPhoneNumber.mockResolvedValue(null);
+			userRepository.findByPhoneNumberWithFilter.mockResolvedValue(null);
+
+			const result = await service.searchByPhoneBatch(phoneNumbers);
+
+			expect(result).toEqual([]);
+			expect(searchIndexService.searchByPhoneNumber).toHaveBeenCalledTimes(120);
+		});
+	});
+
 	describe('indexUser', () => {
 		it('indexes the user when found', async () => {
 			const user = mockUser();


### PR DESCRIPTION
## Summary
- Add unit tests for `UserSearchService.searchByPhoneBatch` covering the full decision tree of the batch path
- Cases: empty input short-circuit, multi-number happy path, no-match filtering, privacy (`searchByPhone=false`) filtering, per-item failure tolerance, chunking beyond 50 numbers
- No production code changes — the feature was already on `main`; this PR just closes the coverage gap that was flagged during the PR #72 review

## Test plan
- [x] `npx jest --testPathPatterns="user-search.service" --no-coverage` — 323 tests green (+6 new)
- [x] Lint clean
- [x] No behavioural change, only new assertions

Closes WHISPR-766