### PR TITLE
feat(contacts): add contact requests (send/accept/reject/cancel)

### DIFF
--- a/src/database/migrations/1775488800000-CreateContactRequests.ts
+++ b/src/database/migrations/1775488800000-CreateContactRequests.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateContactRequests1775488800000 implements MigrationInterface {
+	name = 'CreateContactRequests1775488800000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE TYPE "users"."contact_requests_status_enum" AS ENUM ('pending', 'accepted', 'rejected')`
+		);
+		await queryRunner.query(
+			`CREATE TABLE "users"."contact_requests" (
+				"id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+				"requester_id" uuid NOT NULL,
+				"recipient_id" uuid NOT NULL,
+				"status" "users"."contact_requests_status_enum" NOT NULL DEFAULT 'pending',
+				"created_at" TIMESTAMP NOT NULL DEFAULT now(),
+				"updated_at" TIMESTAMP NOT NULL DEFAULT now(),
+				CONSTRAINT "UQ_contact_requests_requester_recipient" UNIQUE ("requester_id", "recipient_id"),
+				CONSTRAINT "PK_contact_requests" PRIMARY KEY ("id")
+			)`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "users"."contact_requests" ADD CONSTRAINT "FK_contact_requests_requester" FOREIGN KEY ("requester_id") REFERENCES "users"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "users"."contact_requests" ADD CONSTRAINT "FK_contact_requests_recipient" FOREIGN KEY ("recipient_id") REFERENCES "users"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_contact_requests_recipient_status" ON "users"."contact_requests" ("recipient_id", "status")`
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_contact_requests_requester_status" ON "users"."contact_requests" ("requester_id", "status")`
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP INDEX "users"."IDX_contact_requests_requester_status"`);
+		await queryRunner.query(`DROP INDEX "users"."IDX_contact_requests_recipient_status"`);
+		await queryRunner.query(
+			`ALTER TABLE "users"."contact_requests" DROP CONSTRAINT "FK_contact_requests_recipient"`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "users"."contact_requests" DROP CONSTRAINT "FK_contact_requests_requester"`
+		);
+		await queryRunner.query(`DROP TABLE "users"."contact_requests"`);
+		await queryRunner.query(`DROP TYPE "users"."contact_requests_status_enum"`);
+	}
+}

--- a/src/modules/contacts/contacts.module.ts
+++ b/src/modules/contacts/contacts.module.ts
@@ -2,14 +2,18 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommonModule } from '../common/common.module';
 import { Contact } from './entities/contact.entity';
+import { ContactRequest } from './entities/contact-request.entity';
 import { ContactsRepository } from './repositories/contacts.repository';
+import { ContactRequestsRepository } from './repositories/contact-requests.repository';
 import { ContactsService } from './services/contacts.service';
+import { ContactRequestsService } from './services/contact-requests.service';
 import { ContactsController } from './controllers/contacts.controller';
+import { ContactRequestsController } from './controllers/contact-requests.controller';
 
 @Module({
-	imports: [CommonModule, TypeOrmModule.forFeature([Contact])],
-	controllers: [ContactsController],
-	providers: [ContactsService, ContactsRepository],
-	exports: [ContactsService],
+	imports: [CommonModule, TypeOrmModule.forFeature([Contact, ContactRequest])],
+	controllers: [ContactsController, ContactRequestsController],
+	providers: [ContactsService, ContactsRepository, ContactRequestsService, ContactRequestsRepository],
+	exports: [ContactsService, ContactRequestsService],
 })
 export class ContactsModule {}

--- a/src/modules/contacts/controllers/contact-requests.controller.spec.ts
+++ b/src/modules/contacts/controllers/contact-requests.controller.spec.ts
@@ -1,0 +1,111 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import type { Request as ExpressRequest } from 'express';
+import { ContactRequestsController } from './contact-requests.controller';
+import { ContactRequestsService } from '../services/contact-requests.service';
+import { ContactRequest, ContactRequestStatus } from '../entities/contact-request.entity';
+import { SendContactRequestDto } from '../dto/send-contact-request.dto';
+import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+
+const mockRequest = (): ContactRequest =>
+	({
+		id: 'req-1',
+		requesterId: 'uuid-a',
+		recipientId: 'uuid-b',
+		status: ContactRequestStatus.PENDING,
+	}) as ContactRequest;
+
+const makeReq = (sub: string): ExpressRequest & { user: JwtPayload } =>
+	({ user: { sub } as JwtPayload }) as ExpressRequest & { user: JwtPayload };
+
+describe('ContactRequestsController', () => {
+	let controller: ContactRequestsController;
+	let service: jest.Mocked<ContactRequestsService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [ContactRequestsController],
+			providers: [
+				{
+					provide: ContactRequestsService,
+					useValue: {
+						sendRequest: jest.fn(),
+						getRequestsForUser: jest.fn(),
+						acceptRequest: jest.fn(),
+						rejectRequest: jest.fn(),
+						cancelRequest: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		controller = module.get<ContactRequestsController>(ContactRequestsController);
+		service = module.get(ContactRequestsService);
+	});
+
+	describe('sendRequest', () => {
+		it('uses the authenticated user as the requester', async () => {
+			const created = mockRequest();
+			service.sendRequest.mockResolvedValue(created);
+			const dto: SendContactRequestDto = { contactId: 'uuid-b' };
+
+			const result = await controller.sendRequest(makeReq('uuid-a'), dto);
+
+			expect(result).toBe(created);
+			expect(service.sendRequest).toHaveBeenCalledWith('uuid-a', 'uuid-b');
+		});
+	});
+
+	describe('getRequests', () => {
+		it('returns requests when the caller owns them', async () => {
+			const requests = [mockRequest()];
+			service.getRequestsForUser.mockResolvedValue(requests);
+
+			const result = await controller.getRequests('uuid-a', makeReq('uuid-a'));
+
+			expect(result).toBe(requests);
+			expect(service.getRequestsForUser).toHaveBeenCalledWith('uuid-a');
+		});
+
+		it('throws Forbidden when the caller targets another user', async () => {
+			await expect(controller.getRequests('uuid-a', makeReq('uuid-b'))).rejects.toThrow(
+				ForbiddenException
+			);
+			expect(service.getRequestsForUser).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('acceptRequest', () => {
+		it('delegates to the service with the caller user id', async () => {
+			const accepted = { ...mockRequest(), status: ContactRequestStatus.ACCEPTED } as ContactRequest;
+			service.acceptRequest.mockResolvedValue(accepted);
+
+			const result = await controller.acceptRequest(makeReq('uuid-b'), 'req-1');
+
+			expect(result).toBe(accepted);
+			expect(service.acceptRequest).toHaveBeenCalledWith('req-1', 'uuid-b');
+		});
+	});
+
+	describe('rejectRequest', () => {
+		it('delegates to the service with the caller user id', async () => {
+			const rejected = { ...mockRequest(), status: ContactRequestStatus.REJECTED } as ContactRequest;
+			service.rejectRequest.mockResolvedValue(rejected);
+
+			const result = await controller.rejectRequest(makeReq('uuid-b'), 'req-1');
+
+			expect(result).toBe(rejected);
+			expect(service.rejectRequest).toHaveBeenCalledWith('req-1', 'uuid-b');
+		});
+	});
+
+	describe('cancelRequest', () => {
+		it('delegates to the service with the caller user id', async () => {
+			service.cancelRequest.mockResolvedValue(undefined);
+
+			await controller.cancelRequest(makeReq('uuid-a'), 'req-1');
+
+			expect(service.cancelRequest).toHaveBeenCalledWith('req-1', 'uuid-a');
+		});
+	});
+});

--- a/src/modules/contacts/controllers/contact-requests.controller.ts
+++ b/src/modules/contacts/controllers/contact-requests.controller.ts
@@ -1,0 +1,114 @@
+import {
+	Controller,
+	ForbiddenException,
+	Get,
+	Post,
+	Patch,
+	Delete,
+	Param,
+	Body,
+	ParseUUIDPipe,
+	HttpCode,
+	HttpStatus,
+	Request,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
+import type { Request as ExpressRequest } from 'express';
+import { ContactRequestsService } from '../services/contact-requests.service';
+import { SendContactRequestDto } from '../dto/send-contact-request.dto';
+import { ContactRequest } from '../entities/contact-request.entity';
+import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+
+function assertOwnership(req: ExpressRequest & { user?: JwtPayload }, ownerId: string): void {
+	if (req.user?.sub !== ownerId) {
+		throw new ForbiddenException("Cannot access another user's contact requests");
+	}
+}
+
+@ApiTags('Contact Requests')
+@ApiBearerAuth()
+@Controller('contact-requests')
+export class ContactRequestsController {
+	constructor(private readonly contactRequestsService: ContactRequestsService) {}
+
+	@Post()
+	@ApiOperation({ summary: 'Send a contact request' })
+	@ApiResponse({ status: HttpStatus.CREATED, description: 'Contact request sent successfully' })
+	@ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Cannot send request to yourself' })
+	@ApiResponse({
+		status: HttpStatus.CONFLICT,
+		description: 'Already contacts or pending request exists',
+	})
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
+	async sendRequest(
+		@Request() req: ExpressRequest & { user: JwtPayload },
+		@Body() dto: SendContactRequestDto
+	): Promise<ContactRequest> {
+		return this.contactRequestsService.sendRequest(req.user.sub, dto.contactId);
+	}
+
+	@Get(':userId')
+	@ApiOperation({ summary: 'Get all contact requests for a user (incoming + outgoing)' })
+	@ApiParam({ name: 'userId', type: 'string', format: 'uuid', description: 'User ID' })
+	@ApiResponse({ status: HttpStatus.OK, description: 'Contact requests retrieved successfully' })
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
+	@ApiResponse({
+		status: HttpStatus.FORBIDDEN,
+		description: "Cannot access another user's contact requests",
+	})
+	async getRequests(
+		@Param('userId', ParseUUIDPipe) userId: string,
+		@Request() req: ExpressRequest & { user: JwtPayload }
+	): Promise<ContactRequest[]> {
+		assertOwnership(req, userId);
+		return this.contactRequestsService.getRequestsForUser(userId);
+	}
+
+	@Patch(':requestId/accept')
+	@ApiOperation({ summary: 'Accept a contact request' })
+	@ApiParam({ name: 'requestId', type: 'string', format: 'uuid', description: 'Request ID' })
+	@ApiResponse({ status: HttpStatus.OK, description: 'Contact request accepted' })
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Contact request not found' })
+	@ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Only the recipient can accept' })
+	@ApiResponse({ status: HttpStatus.CONFLICT, description: 'Request is not pending' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
+	async acceptRequest(
+		@Request() req: ExpressRequest & { user: JwtPayload },
+		@Param('requestId', ParseUUIDPipe) requestId: string
+	): Promise<ContactRequest> {
+		return this.contactRequestsService.acceptRequest(requestId, req.user.sub);
+	}
+
+	@Patch(':requestId/reject')
+	@ApiOperation({ summary: 'Reject a contact request' })
+	@ApiParam({ name: 'requestId', type: 'string', format: 'uuid', description: 'Request ID' })
+	@ApiResponse({ status: HttpStatus.OK, description: 'Contact request rejected' })
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Contact request not found' })
+	@ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Only the recipient can reject' })
+	@ApiResponse({ status: HttpStatus.CONFLICT, description: 'Request is not pending' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
+	async rejectRequest(
+		@Request() req: ExpressRequest & { user: JwtPayload },
+		@Param('requestId', ParseUUIDPipe) requestId: string
+	): Promise<ContactRequest> {
+		return this.contactRequestsService.rejectRequest(requestId, req.user.sub);
+	}
+
+	@Delete(':requestId')
+	@HttpCode(HttpStatus.NO_CONTENT)
+	@ApiOperation({ summary: 'Cancel a sent contact request' })
+	@ApiParam({ name: 'requestId', type: 'string', format: 'uuid', description: 'Request ID' })
+	@ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'Contact request cancelled' })
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Contact request not found' })
+	@ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Only the requester can cancel' })
+	@ApiResponse({ status: HttpStatus.CONFLICT, description: 'Request is not pending' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
+	async cancelRequest(
+		@Request() req: ExpressRequest & { user: JwtPayload },
+		@Param('requestId', ParseUUIDPipe) requestId: string
+	): Promise<void> {
+		return this.contactRequestsService.cancelRequest(requestId, req.user.sub);
+	}
+}

--- a/src/modules/contacts/dto/send-contact-request.dto.ts
+++ b/src/modules/contacts/dto/send-contact-request.dto.ts
@@ -1,0 +1,8 @@
+import { IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SendContactRequestDto {
+	@ApiProperty({ description: 'UUID of the user to send the request to', format: 'uuid' })
+	@IsUUID()
+	contactId: string;
+}

--- a/src/modules/contacts/entities/contact-request.entity.ts
+++ b/src/modules/contacts/entities/contact-request.entity.ts
@@ -1,0 +1,56 @@
+import {
+	Entity,
+	PrimaryGeneratedColumn,
+	Column,
+	CreateDateColumn,
+	UpdateDateColumn,
+	ManyToOne,
+	JoinColumn,
+	Unique,
+	Index,
+} from 'typeorm';
+import { User } from '../../common/entities/user.entity';
+
+export enum ContactRequestStatus {
+	PENDING = 'pending',
+	ACCEPTED = 'accepted',
+	REJECTED = 'rejected',
+}
+
+@Entity({ name: 'contact_requests', schema: 'users' })
+@Unique('UQ_contact_requests_requester_recipient', ['requesterId', 'recipientId'])
+@Index('IDX_contact_requests_recipient_status', ['recipientId', 'status'])
+@Index('IDX_contact_requests_requester_status', ['requesterId', 'status'])
+export class ContactRequest {
+	@PrimaryGeneratedColumn('uuid')
+	id: string;
+
+	@Column({ name: 'requester_id', type: 'uuid' })
+	requesterId: string;
+
+	@ManyToOne(() => User, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'requester_id' })
+	requester: User;
+
+	@Column({ name: 'recipient_id', type: 'uuid' })
+	recipientId: string;
+
+	@ManyToOne(() => User, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'recipient_id' })
+	recipient: User;
+
+	@Column({
+		name: 'status',
+		type: 'enum',
+		enum: ContactRequestStatus,
+		enumName: 'contact_requests_status_enum',
+		default: ContactRequestStatus.PENDING,
+	})
+	status: ContactRequestStatus;
+
+	@CreateDateColumn({ name: 'created_at' })
+	createdAt: Date;
+
+	@UpdateDateColumn({ name: 'updated_at' })
+	updatedAt: Date;
+}

--- a/src/modules/contacts/repositories/contact-requests.repository.ts
+++ b/src/modules/contacts/repositories/contact-requests.repository.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ContactRequest, ContactRequestStatus } from '../entities/contact-request.entity';
+
+@Injectable()
+export class ContactRequestsRepository {
+	constructor(
+		@InjectRepository(ContactRequest)
+		private readonly repo: Repository<ContactRequest>
+	) {}
+
+	async findById(id: string): Promise<ContactRequest | null> {
+		return this.repo.findOne({ where: { id } });
+	}
+
+	async findPendingBetween(userA: string, userB: string): Promise<ContactRequest | null> {
+		return this.repo.findOne({
+			where: [
+				{ requesterId: userA, recipientId: userB, status: ContactRequestStatus.PENDING },
+				{ requesterId: userB, recipientId: userA, status: ContactRequestStatus.PENDING },
+			],
+		});
+	}
+
+	async findAllForUser(userId: string): Promise<ContactRequest[]> {
+		return this.repo.find({
+			where: [{ requesterId: userId }, { recipientId: userId }],
+			relations: ['requester', 'recipient'],
+			order: { createdAt: 'DESC' },
+		});
+	}
+
+	async create(requesterId: string, recipientId: string): Promise<ContactRequest> {
+		const request = this.repo.create({
+			requesterId,
+			recipientId,
+			status: ContactRequestStatus.PENDING,
+		});
+		return this.repo.save(request);
+	}
+
+	async save(request: ContactRequest): Promise<ContactRequest> {
+		return this.repo.save(request);
+	}
+
+	async remove(request: ContactRequest): Promise<void> {
+		await this.repo.remove(request);
+	}
+}

--- a/src/modules/contacts/services/contact-requests.service.spec.ts
+++ b/src/modules/contacts/services/contact-requests.service.spec.ts
@@ -1,0 +1,307 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import {
+	NotFoundException,
+	ConflictException,
+	BadRequestException,
+	ForbiddenException,
+} from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { ContactRequestsService } from './contact-requests.service';
+import { UserRepository } from '../../common/repositories';
+import { ContactRequestsRepository } from '../repositories/contact-requests.repository';
+import { ContactsRepository } from '../repositories/contacts.repository';
+import { ContactRequest, ContactRequestStatus } from '../entities/contact-request.entity';
+import { Contact } from '../entities/contact.entity';
+import { User } from '../../common/entities/user.entity';
+
+const mockUser = (id: string): User => ({ id }) as User;
+
+const mockRequest = (overrides: Partial<ContactRequest> = {}): ContactRequest =>
+	({
+		id: 'req-1',
+		requesterId: 'uuid-a',
+		recipientId: 'uuid-b',
+		status: ContactRequestStatus.PENDING,
+		createdAt: new Date('2024-01-01'),
+		updatedAt: new Date('2024-01-01'),
+		...overrides,
+	}) as ContactRequest;
+
+describe('ContactRequestsService', () => {
+	let service: ContactRequestsService;
+	let userRepository: jest.Mocked<UserRepository>;
+	let contactRequestsRepository: jest.Mocked<ContactRequestsRepository>;
+	let contactsRepository: jest.Mocked<ContactsRepository>;
+	let transactionalContactRepo: {
+		findOne: jest.Mock;
+		create: jest.Mock;
+		save: jest.Mock;
+	};
+	let transactionalRequestRepo: {
+		save: jest.Mock;
+	};
+	let commitTransaction: jest.Mock;
+	let rollbackTransaction: jest.Mock;
+	let release: jest.Mock;
+
+	beforeEach(async () => {
+		transactionalContactRepo = {
+			findOne: jest.fn(),
+			create: jest.fn((entity: Partial<Contact>) => entity as Contact),
+			save: jest.fn(async (entity: Partial<Contact>) => entity as Contact),
+		};
+		transactionalRequestRepo = {
+			save: jest.fn(async (entity: ContactRequest) => entity),
+		};
+		commitTransaction = jest.fn();
+		rollbackTransaction = jest.fn();
+		release = jest.fn();
+
+		const queryRunner = {
+			connect: jest.fn(),
+			startTransaction: jest.fn(),
+			commitTransaction,
+			rollbackTransaction,
+			release,
+			manager: {
+				getRepository: jest.fn((entity) => {
+					if (entity === Contact) return transactionalContactRepo;
+					if (entity === ContactRequest) return transactionalRequestRepo;
+					throw new Error(`Unexpected entity in test: ${String(entity)}`);
+				}),
+			},
+		};
+
+		const dataSource = {
+			createQueryRunner: jest.fn(() => queryRunner),
+		} as unknown as DataSource;
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				ContactRequestsService,
+				{
+					provide: UserRepository,
+					useValue: { findById: jest.fn() },
+				},
+				{
+					provide: ContactRequestsRepository,
+					useValue: {
+						findById: jest.fn(),
+						findPendingBetween: jest.fn(),
+						findAllForUser: jest.fn(),
+						create: jest.fn(),
+						save: jest.fn(),
+						remove: jest.fn(),
+					},
+				},
+				{
+					provide: ContactsRepository,
+					useValue: { findOne: jest.fn() },
+				},
+				{
+					provide: getDataSourceToken(),
+					useValue: dataSource,
+				},
+			],
+		}).compile();
+
+		service = module.get<ContactRequestsService>(ContactRequestsService);
+		userRepository = module.get(UserRepository);
+		contactRequestsRepository = module.get(ContactRequestsRepository);
+		contactsRepository = module.get(ContactsRepository);
+	});
+
+	describe('sendRequest', () => {
+		it('throws BadRequest when requester equals recipient', async () => {
+			await expect(service.sendRequest('uuid-a', 'uuid-a')).rejects.toThrow(BadRequestException);
+			expect(userRepository.findById).not.toHaveBeenCalled();
+		});
+
+		it('throws NotFound when requester does not exist', async () => {
+			userRepository.findById.mockResolvedValueOnce(null);
+			await expect(service.sendRequest('uuid-a', 'uuid-b')).rejects.toThrow(NotFoundException);
+		});
+
+		it('throws NotFound when recipient does not exist', async () => {
+			userRepository.findById.mockResolvedValueOnce(mockUser('uuid-a')).mockResolvedValueOnce(null);
+			await expect(service.sendRequest('uuid-a', 'uuid-b')).rejects.toThrow(NotFoundException);
+		});
+
+		it('throws Conflict when users are already contacts', async () => {
+			userRepository.findById.mockResolvedValue(mockUser('uuid-a'));
+			contactsRepository.findOne.mockResolvedValue({ id: 'c-1' } as Contact);
+
+			await expect(service.sendRequest('uuid-a', 'uuid-b')).rejects.toThrow(ConflictException);
+		});
+
+		it('throws Conflict when a pending request exists in either direction', async () => {
+			userRepository.findById.mockResolvedValue(mockUser('uuid-a'));
+			contactsRepository.findOne.mockResolvedValue(null);
+			contactRequestsRepository.findPendingBetween.mockResolvedValue(mockRequest());
+
+			await expect(service.sendRequest('uuid-a', 'uuid-b')).rejects.toThrow(ConflictException);
+			expect(contactRequestsRepository.findPendingBetween).toHaveBeenCalledWith('uuid-a', 'uuid-b');
+		});
+
+		it('creates a new pending request when inputs are valid', async () => {
+			const created = mockRequest();
+			userRepository.findById.mockResolvedValue(mockUser('uuid-a'));
+			contactsRepository.findOne.mockResolvedValue(null);
+			contactRequestsRepository.findPendingBetween.mockResolvedValue(null);
+			contactRequestsRepository.create.mockResolvedValue(created);
+
+			const result = await service.sendRequest('uuid-a', 'uuid-b');
+
+			expect(result).toBe(created);
+			expect(contactRequestsRepository.create).toHaveBeenCalledWith('uuid-a', 'uuid-b');
+		});
+	});
+
+	describe('getRequestsForUser', () => {
+		it('throws NotFound when user does not exist', async () => {
+			userRepository.findById.mockResolvedValue(null);
+			await expect(service.getRequestsForUser('uuid-a')).rejects.toThrow(NotFoundException);
+		});
+
+		it('delegates to repository when user exists', async () => {
+			const requests = [mockRequest()];
+			userRepository.findById.mockResolvedValue(mockUser('uuid-a'));
+			contactRequestsRepository.findAllForUser.mockResolvedValue(requests);
+
+			const result = await service.getRequestsForUser('uuid-a');
+
+			expect(result).toBe(requests);
+			expect(contactRequestsRepository.findAllForUser).toHaveBeenCalledWith('uuid-a');
+		});
+	});
+
+	describe('acceptRequest', () => {
+		it('throws NotFound when request does not exist', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(null);
+			await expect(service.acceptRequest('req-1', 'uuid-b')).rejects.toThrow(NotFoundException);
+		});
+
+		it('throws Forbidden when the caller is not the recipient', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(mockRequest());
+			await expect(service.acceptRequest('req-1', 'uuid-a')).rejects.toThrow(ForbiddenException);
+		});
+
+		it('throws Conflict when the request is not pending', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(
+				mockRequest({ status: ContactRequestStatus.ACCEPTED })
+			);
+			await expect(service.acceptRequest('req-1', 'uuid-b')).rejects.toThrow(ConflictException);
+		});
+
+		it('creates bidirectional contacts and updates status in a transaction', async () => {
+			const request = mockRequest();
+			contactRequestsRepository.findById.mockResolvedValue(request);
+			transactionalContactRepo.findOne.mockResolvedValue(null);
+
+			const result = await service.acceptRequest('req-1', 'uuid-b');
+
+			expect(transactionalContactRepo.save).toHaveBeenCalledTimes(2);
+			expect(transactionalContactRepo.save).toHaveBeenNthCalledWith(
+				1,
+				expect.objectContaining({ ownerId: 'uuid-a', contactId: 'uuid-b' })
+			);
+			expect(transactionalContactRepo.save).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({ ownerId: 'uuid-b', contactId: 'uuid-a' })
+			);
+			expect(transactionalRequestRepo.save).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'req-1', status: ContactRequestStatus.ACCEPTED })
+			);
+			expect(commitTransaction).toHaveBeenCalled();
+			expect(rollbackTransaction).not.toHaveBeenCalled();
+			expect(release).toHaveBeenCalled();
+			expect(result.status).toBe(ContactRequestStatus.ACCEPTED);
+		});
+
+		it('skips creation of an existing contact row', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(mockRequest());
+			transactionalContactRepo.findOne
+				.mockResolvedValueOnce({ id: 'c-ab' } as Contact)
+				.mockResolvedValueOnce(null);
+
+			await service.acceptRequest('req-1', 'uuid-b');
+
+			expect(transactionalContactRepo.save).toHaveBeenCalledTimes(1);
+			expect(transactionalContactRepo.save).toHaveBeenCalledWith(
+				expect.objectContaining({ ownerId: 'uuid-b', contactId: 'uuid-a' })
+			);
+		});
+
+		it('rolls back the transaction on failure', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(mockRequest());
+			transactionalContactRepo.findOne.mockResolvedValue(null);
+			transactionalContactRepo.save.mockRejectedValueOnce(new Error('DB boom'));
+
+			await expect(service.acceptRequest('req-1', 'uuid-b')).rejects.toThrow('DB boom');
+			expect(commitTransaction).not.toHaveBeenCalled();
+			expect(rollbackTransaction).toHaveBeenCalled();
+			expect(release).toHaveBeenCalled();
+		});
+	});
+
+	describe('rejectRequest', () => {
+		it('throws NotFound when request does not exist', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(null);
+			await expect(service.rejectRequest('req-1', 'uuid-b')).rejects.toThrow(NotFoundException);
+		});
+
+		it('throws Forbidden when the caller is not the recipient', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(mockRequest());
+			await expect(service.rejectRequest('req-1', 'uuid-a')).rejects.toThrow(ForbiddenException);
+		});
+
+		it('throws Conflict when the request is not pending', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(
+				mockRequest({ status: ContactRequestStatus.REJECTED })
+			);
+			await expect(service.rejectRequest('req-1', 'uuid-b')).rejects.toThrow(ConflictException);
+		});
+
+		it('updates status to rejected', async () => {
+			const request = mockRequest();
+			contactRequestsRepository.findById.mockResolvedValue(request);
+			contactRequestsRepository.save.mockImplementation(async (r) => r);
+
+			const result = await service.rejectRequest('req-1', 'uuid-b');
+
+			expect(result.status).toBe(ContactRequestStatus.REJECTED);
+			expect(contactRequestsRepository.save).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'req-1', status: ContactRequestStatus.REJECTED })
+			);
+		});
+	});
+
+	describe('cancelRequest', () => {
+		it('throws NotFound when request does not exist', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(null);
+			await expect(service.cancelRequest('req-1', 'uuid-a')).rejects.toThrow(NotFoundException);
+		});
+
+		it('throws Forbidden when the caller is not the requester', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(mockRequest());
+			await expect(service.cancelRequest('req-1', 'uuid-b')).rejects.toThrow(ForbiddenException);
+		});
+
+		it('throws Conflict when the request is not pending', async () => {
+			contactRequestsRepository.findById.mockResolvedValue(
+				mockRequest({ status: ContactRequestStatus.ACCEPTED })
+			);
+			await expect(service.cancelRequest('req-1', 'uuid-a')).rejects.toThrow(ConflictException);
+		});
+
+		it('removes the request when valid', async () => {
+			const request = mockRequest();
+			contactRequestsRepository.findById.mockResolvedValue(request);
+
+			await service.cancelRequest('req-1', 'uuid-a');
+
+			expect(contactRequestsRepository.remove).toHaveBeenCalledWith(request);
+		});
+	});
+});

--- a/src/modules/contacts/services/contact-requests.service.ts
+++ b/src/modules/contacts/services/contact-requests.service.ts
@@ -1,0 +1,157 @@
+import {
+	Injectable,
+	NotFoundException,
+	ConflictException,
+	BadRequestException,
+	ForbiddenException,
+} from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { UserRepository } from '../../common/repositories';
+import { ContactRequestsRepository } from '../repositories/contact-requests.repository';
+import { ContactsRepository } from '../repositories/contacts.repository';
+import { Contact } from '../entities/contact.entity';
+import { ContactRequest, ContactRequestStatus } from '../entities/contact-request.entity';
+
+@Injectable()
+export class ContactRequestsService {
+	constructor(
+		private readonly userRepository: UserRepository,
+		private readonly contactRequestsRepository: ContactRequestsRepository,
+		private readonly contactsRepository: ContactsRepository,
+		@InjectDataSource()
+		private readonly dataSource: DataSource
+	) {}
+
+	private async ensureUserExists(userId: string): Promise<void> {
+		const user = await this.userRepository.findById(userId);
+		if (!user) {
+			throw new NotFoundException('User not found');
+		}
+	}
+
+	async sendRequest(requesterId: string, recipientId: string): Promise<ContactRequest> {
+		if (requesterId === recipientId) {
+			throw new BadRequestException('Cannot send a contact request to yourself');
+		}
+
+		await this.ensureUserExists(requesterId);
+		await this.ensureUserExists(recipientId);
+
+		const existingContact = await this.contactsRepository.findOne(requesterId, recipientId);
+		if (existingContact) {
+			throw new ConflictException('Already in contacts');
+		}
+
+		const existingRequest = await this.contactRequestsRepository.findPendingBetween(
+			requesterId,
+			recipientId
+		);
+		if (existingRequest) {
+			throw new ConflictException('A pending contact request already exists');
+		}
+
+		return this.contactRequestsRepository.create(requesterId, recipientId);
+	}
+
+	async getRequestsForUser(userId: string): Promise<ContactRequest[]> {
+		await this.ensureUserExists(userId);
+		return this.contactRequestsRepository.findAllForUser(userId);
+	}
+
+	async acceptRequest(requestId: string, userId: string): Promise<ContactRequest> {
+		const request = await this.contactRequestsRepository.findById(requestId);
+		if (!request) {
+			throw new NotFoundException('Contact request not found');
+		}
+
+		if (request.recipientId !== userId) {
+			throw new ForbiddenException('Only the recipient can accept a contact request');
+		}
+
+		if (request.status !== ContactRequestStatus.PENDING) {
+			throw new ConflictException('Contact request is not pending');
+		}
+
+		const queryRunner = this.dataSource.createQueryRunner();
+		await queryRunner.connect();
+		await queryRunner.startTransaction();
+
+		try {
+			const contactRepo = queryRunner.manager.getRepository(Contact);
+			const requestRepo = queryRunner.manager.getRepository(ContactRequest);
+
+			const existingAB = await contactRepo.findOne({
+				where: { ownerId: request.requesterId, contactId: request.recipientId },
+			});
+			if (!existingAB) {
+				await contactRepo.save(
+					contactRepo.create({
+						ownerId: request.requesterId,
+						contactId: request.recipientId,
+						nickname: null,
+					})
+				);
+			}
+
+			const existingBA = await contactRepo.findOne({
+				where: { ownerId: request.recipientId, contactId: request.requesterId },
+			});
+			if (!existingBA) {
+				await contactRepo.save(
+					contactRepo.create({
+						ownerId: request.recipientId,
+						contactId: request.requesterId,
+						nickname: null,
+					})
+				);
+			}
+
+			request.status = ContactRequestStatus.ACCEPTED;
+			const saved = await requestRepo.save(request);
+
+			await queryRunner.commitTransaction();
+			return saved;
+		} catch (err) {
+			await queryRunner.rollbackTransaction();
+			throw err;
+		} finally {
+			await queryRunner.release();
+		}
+	}
+
+	async rejectRequest(requestId: string, userId: string): Promise<ContactRequest> {
+		const request = await this.contactRequestsRepository.findById(requestId);
+		if (!request) {
+			throw new NotFoundException('Contact request not found');
+		}
+
+		if (request.recipientId !== userId) {
+			throw new ForbiddenException('Only the recipient can reject a contact request');
+		}
+
+		if (request.status !== ContactRequestStatus.PENDING) {
+			throw new ConflictException('Contact request is not pending');
+		}
+
+		request.status = ContactRequestStatus.REJECTED;
+		return this.contactRequestsRepository.save(request);
+	}
+
+	async cancelRequest(requestId: string, userId: string): Promise<void> {
+		const request = await this.contactRequestsRepository.findById(requestId);
+		if (!request) {
+			throw new NotFoundException('Contact request not found');
+		}
+
+		if (request.requesterId !== userId) {
+			throw new ForbiddenException('Only the requester can cancel a contact request');
+		}
+
+		if (request.status !== ContactRequestStatus.PENDING) {
+			throw new ConflictException('Contact request is not pending');
+		}
+
+		await this.contactRequestsRepository.remove(request);
+	}
+}


### PR DESCRIPTION
## Summary
- New contact-request workflow: users can send a request, the recipient accepts/rejects, the requester can cancel a pending one. Accepting creates a bidirectional contact.
- Migration `CreateContactRequests` (table `users.contact_requests`, enum status, FK CASCADE, unique `(requester_id, recipient_id)`, indexes on `(recipient_id, status)` and `(requester_id, status)`)
- Entity, repository, service, controller, DTO wired through `ContactsModule`

## Hardening over the PR #72 draft
- **Ownership**: `GET /contact-requests/:userId` now enforces `req.user.sub === userId` via `assertOwnership`, matching `ContactsController`
- **Typing**: `JwtPayload` everywhere, no `any` on `req.user`
- **Transaction**: `acceptRequest` wraps the two `Contact` inserts + request status update in a `QueryRunner` transaction so partial failures roll back
- **N+1**: `findAllForUser` loads `requester`/`recipient` via TypeORM `relations`, no per-row `findById` fan-out
- **Indexes**: added `(recipient_id, status)` and `(requester_id, status)` for the hot paths

## Test plan
- [x] Unit tests for `ContactRequestsService` — all branches (not-found, forbidden, conflict, happy path, transaction commit, transaction rollback)
- [x] Unit tests for `ContactRequestsController` — ownership enforcement + delegation
- [x] `npx jest --no-coverage` → 351 green (+28 new)
- [x] Lint + prettier clean
- [ ] e2e already covered by existing suite; new endpoints exercised through unit tests

Closes WHISPR-767