### PR TITLE
test(coverage): add unit tests for controllers and repositories

### DIFF
--- a/src/modules/accounts/events/events.spec.ts
+++ b/src/modules/accounts/events/events.spec.ts
@@ -1,0 +1,43 @@
+import { UserUpdatedEvent } from './user-updated.event';
+import { UserDeactivatedEvent } from './user-deactivated.event';
+
+describe('UserUpdatedEvent', () => {
+	it('exposes all constructor fields as readonly properties', () => {
+		const event = new UserUpdatedEvent(
+			'user-1',
+			'alice',
+			'Alice',
+			'Smith',
+			'https://cdn.example.com/a.png',
+			true
+		);
+
+		expect(event.userId).toBe('user-1');
+		expect(event.username).toBe('alice');
+		expect(event.firstName).toBe('Alice');
+		expect(event.lastName).toBe('Smith');
+		expect(event.profilePictureUrl).toBe('https://cdn.example.com/a.png');
+		expect(event.isActive).toBe(true);
+	});
+
+	it('leaves optional fields undefined when not provided', () => {
+		const event = new UserUpdatedEvent('user-1');
+
+		expect(event.userId).toBe('user-1');
+		expect(event.username).toBeUndefined();
+		expect(event.firstName).toBeUndefined();
+		expect(event.lastName).toBeUndefined();
+		expect(event.profilePictureUrl).toBeUndefined();
+		expect(event.isActive).toBeUndefined();
+	});
+});
+
+describe('UserDeactivatedEvent', () => {
+	it('exposes userId and deactivatedAt as readonly properties', () => {
+		const deactivatedAt = new Date('2026-01-01T00:00:00Z');
+		const event = new UserDeactivatedEvent('user-1', deactivatedAt);
+
+		expect(event.userId).toBe('user-1');
+		expect(event.deactivatedAt).toBe(deactivatedAt);
+	});
+});

--- a/src/modules/blocked-users/controllers/blocked-users.controller.spec.ts
+++ b/src/modules/blocked-users/controllers/blocked-users.controller.spec.ts
@@ -1,0 +1,64 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BlockedUsersController } from './blocked-users.controller';
+import { BlockedUsersService } from '../services/blocked-users.service';
+import { BlockedUser } from '../entities/blocked-user.entity';
+import { BlockUserDto } from '../dto/block-user.dto';
+
+describe('BlockedUsersController', () => {
+	let controller: BlockedUsersController;
+	let service: jest.Mocked<BlockedUsersService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [BlockedUsersController],
+			providers: [
+				{
+					provide: BlockedUsersService,
+					useValue: {
+						getBlockedUsers: jest.fn(),
+						blockUser: jest.fn(),
+						unblockUser: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		controller = module.get<BlockedUsersController>(BlockedUsersController);
+		service = module.get(BlockedUsersService);
+	});
+
+	describe('getBlockedUsers', () => {
+		it('delegates to the service', async () => {
+			const rows = [{ id: 'b1' }] as BlockedUser[];
+			service.getBlockedUsers.mockResolvedValue(rows);
+
+			const result = await controller.getBlockedUsers('blocker-1');
+
+			expect(result).toBe(rows);
+			expect(service.getBlockedUsers).toHaveBeenCalledWith('blocker-1');
+		});
+	});
+
+	describe('blockUser', () => {
+		it('delegates to the service', async () => {
+			const dto: BlockUserDto = { blockedId: 'blocked-1' } as BlockUserDto;
+			const created = { id: 'b1' } as BlockedUser;
+			service.blockUser.mockResolvedValue(created);
+
+			const result = await controller.blockUser('blocker-1', dto);
+
+			expect(result).toBe(created);
+			expect(service.blockUser).toHaveBeenCalledWith('blocker-1', dto);
+		});
+	});
+
+	describe('unblockUser', () => {
+		it('delegates to the service', async () => {
+			service.unblockUser.mockResolvedValue(undefined);
+
+			await controller.unblockUser('blocker-1', 'blocked-1');
+
+			expect(service.unblockUser).toHaveBeenCalledWith('blocker-1', 'blocked-1');
+		});
+	});
+});

--- a/src/modules/blocked-users/repositories/blocked-users.repository.spec.ts
+++ b/src/modules/blocked-users/repositories/blocked-users.repository.spec.ts
@@ -1,0 +1,82 @@
+import { BlockedUsersRepository } from './blocked-users.repository';
+import { BlockedUser } from '../entities/blocked-user.entity';
+
+const mockTypeormRepo = {
+	create: jest.fn(),
+	save: jest.fn(),
+	findOne: jest.fn(),
+	find: jest.fn(),
+	remove: jest.fn(),
+};
+
+describe('BlockedUsersRepository', () => {
+	let repo: BlockedUsersRepository;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		repo = new BlockedUsersRepository(mockTypeormRepo as any);
+	});
+
+	describe('findAllByBlocker', () => {
+		it('returns the blocked users for the blocker', async () => {
+			const rows = [{ id: 'b1' }] as BlockedUser[];
+			mockTypeormRepo.find.mockResolvedValue(rows);
+
+			const result = await repo.findAllByBlocker('blocker-1');
+
+			expect(mockTypeormRepo.find).toHaveBeenCalledWith({ where: { blockerId: 'blocker-1' } });
+			expect(result).toBe(rows);
+		});
+	});
+
+	describe('findOne', () => {
+		it('returns the blocked-user entry when found', async () => {
+			const row = { id: 'b1' } as BlockedUser;
+			mockTypeormRepo.findOne.mockResolvedValue(row);
+
+			const result = await repo.findOne('blocker-1', 'blocked-1');
+
+			expect(mockTypeormRepo.findOne).toHaveBeenCalledWith({
+				where: { blockerId: 'blocker-1', blockedId: 'blocked-1' },
+			});
+			expect(result).toBe(row);
+		});
+
+		it('returns null when not found', async () => {
+			mockTypeormRepo.findOne.mockResolvedValue(null);
+
+			const result = await repo.findOne('blocker-1', 'missing');
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('create', () => {
+		it('creates and saves a blocked-user entry', async () => {
+			const draft = { blockerId: 'blocker-1', blockedId: 'blocked-1' } as BlockedUser;
+			const saved = { id: 'b1', ...draft } as BlockedUser;
+			mockTypeormRepo.create.mockReturnValue(draft);
+			mockTypeormRepo.save.mockResolvedValue(saved);
+
+			const result = await repo.create('blocker-1', 'blocked-1');
+
+			expect(mockTypeormRepo.create).toHaveBeenCalledWith({
+				blockerId: 'blocker-1',
+				blockedId: 'blocked-1',
+			});
+			expect(mockTypeormRepo.save).toHaveBeenCalledWith(draft);
+			expect(result).toBe(saved);
+		});
+	});
+
+	describe('remove', () => {
+		it('delegates to the typeorm remove', async () => {
+			const row = { id: 'b1' } as BlockedUser;
+			mockTypeormRepo.remove.mockResolvedValue(row);
+
+			await repo.remove(row);
+
+			expect(mockTypeormRepo.remove).toHaveBeenCalledWith(row);
+		});
+	});
+});

--- a/src/modules/common/repositories/user.repository.spec.ts
+++ b/src/modules/common/repositories/user.repository.spec.ts
@@ -263,6 +263,47 @@ describe('UserRepository', () => {
 		});
 	});
 
+	describe('searchByDisplayName', () => {
+		it('searches by firstName OR lastName with the default limit and deduplicates results', async () => {
+			const rows = [
+				{ id: 'u1', firstName: 'Alice' },
+				{ id: 'u2', firstName: 'Alicia' },
+				{ id: 'u1', firstName: 'Alice' },
+			] as User[];
+			mockTypeormRepo.find.mockResolvedValue(rows);
+
+			const result = await repo.searchByDisplayName('ali');
+
+			expect(mockTypeormRepo.find).toHaveBeenCalledWith({
+				where: [
+					{ firstName: ILike('%ali%'), isActive: true },
+					{ lastName: ILike('%ali%'), isActive: true },
+				],
+				take: 40,
+				order: { createdAt: 'DESC' },
+			});
+			expect(result).toHaveLength(2);
+			expect(result.map((u) => u.id)).toEqual(['u1', 'u2']);
+		});
+
+		it('respects the limit parameter', async () => {
+			const rows = [{ id: 'u1' }, { id: 'u2' }, { id: 'u3' }] as User[];
+			mockTypeormRepo.find.mockResolvedValue(rows);
+
+			const result = await repo.searchByDisplayName('ali', 2);
+
+			expect(mockTypeormRepo.find).toHaveBeenCalledWith({
+				where: [
+					{ firstName: ILike('%ali%'), isActive: true },
+					{ lastName: ILike('%ali%'), isActive: true },
+				],
+				take: 4,
+				order: { createdAt: 'DESC' },
+			});
+			expect(result).toHaveLength(2);
+		});
+	});
+
 	describe('updateLastSeen', () => {
 		it('should update lastSeen with provided date', async () => {
 			const date = new Date('2024-01-01T00:00:00Z');

--- a/src/modules/contacts/controllers/contacts.controller.spec.ts
+++ b/src/modules/contacts/controllers/contacts.controller.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import type { Request as ExpressRequest } from 'express';
+import { ContactsController } from './contacts.controller';
+import { ContactsService } from '../services/contacts.service';
+import { Contact } from '../entities/contact.entity';
+import { AddContactDto } from '../dto/add-contact.dto';
+import { UpdateContactDto } from '../dto/update-contact.dto';
+import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+
+const makeReq = (sub: string): ExpressRequest & { user: JwtPayload } =>
+	({ user: { sub } as JwtPayload }) as ExpressRequest & { user: JwtPayload };
+
+describe('ContactsController', () => {
+	let controller: ContactsController;
+	let service: jest.Mocked<ContactsService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [ContactsController],
+			providers: [
+				{
+					provide: ContactsService,
+					useValue: {
+						getContacts: jest.fn(),
+						addContact: jest.fn(),
+						updateContact: jest.fn(),
+						removeContact: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		controller = module.get<ContactsController>(ContactsController);
+		service = module.get(ContactsService);
+	});
+
+	describe('getContacts', () => {
+		it('returns the contacts when the caller owns them', async () => {
+			const contacts = [{ id: 'c1' }] as Contact[];
+			service.getContacts.mockResolvedValue(contacts);
+
+			const result = await controller.getContacts('owner-1', makeReq('owner-1'));
+
+			expect(result).toBe(contacts);
+			expect(service.getContacts).toHaveBeenCalledWith('owner-1');
+		});
+
+		it('throws Forbidden when the caller targets another user', async () => {
+			await expect(controller.getContacts('owner-1', makeReq('other'))).rejects.toThrow(
+				ForbiddenException
+			);
+			expect(service.getContacts).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('addContact', () => {
+		it('delegates to the service for the caller', async () => {
+			const dto: AddContactDto = { contactId: 'contact-1' } as AddContactDto;
+			const created = { id: 'c1' } as Contact;
+			service.addContact.mockResolvedValue(created);
+
+			const result = await controller.addContact('owner-1', dto, makeReq('owner-1'));
+
+			expect(result).toBe(created);
+			expect(service.addContact).toHaveBeenCalledWith('owner-1', dto);
+		});
+
+		it('throws Forbidden when the caller targets another user', async () => {
+			const dto: AddContactDto = { contactId: 'contact-1' } as AddContactDto;
+
+			await expect(controller.addContact('owner-1', dto, makeReq('other'))).rejects.toThrow(
+				ForbiddenException
+			);
+			expect(service.addContact).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('updateContact', () => {
+		it('delegates to the service for the caller', async () => {
+			const dto: UpdateContactDto = { nickname: 'Bob' } as UpdateContactDto;
+			const updated = { id: 'c1', nickname: 'Bob' } as Contact;
+			service.updateContact.mockResolvedValue(updated);
+
+			const result = await controller.updateContact('owner-1', 'contact-1', dto, makeReq('owner-1'));
+
+			expect(result).toBe(updated);
+			expect(service.updateContact).toHaveBeenCalledWith('owner-1', 'contact-1', dto);
+		});
+
+		it('throws Forbidden when the caller targets another user', async () => {
+			await expect(
+				controller.updateContact('owner-1', 'contact-1', {} as UpdateContactDto, makeReq('other'))
+			).rejects.toThrow(ForbiddenException);
+			expect(service.updateContact).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('removeContact', () => {
+		it('delegates to the service for the caller', async () => {
+			service.removeContact.mockResolvedValue(undefined);
+
+			await controller.removeContact('owner-1', 'contact-1', makeReq('owner-1'));
+
+			expect(service.removeContact).toHaveBeenCalledWith('owner-1', 'contact-1');
+		});
+
+		it('throws Forbidden when the caller targets another user', async () => {
+			await expect(controller.removeContact('owner-1', 'contact-1', makeReq('other'))).rejects.toThrow(
+				ForbiddenException
+			);
+			expect(service.removeContact).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/modules/contacts/repositories/contact-requests.repository.spec.ts
+++ b/src/modules/contacts/repositories/contact-requests.repository.spec.ts
@@ -1,0 +1,118 @@
+import { ContactRequestsRepository } from './contact-requests.repository';
+import { ContactRequest, ContactRequestStatus } from '../entities/contact-request.entity';
+
+const mockTypeormRepo = {
+	create: jest.fn(),
+	save: jest.fn(),
+	findOne: jest.fn(),
+	find: jest.fn(),
+	remove: jest.fn(),
+};
+
+describe('ContactRequestsRepository', () => {
+	let repo: ContactRequestsRepository;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		repo = new ContactRequestsRepository(mockTypeormRepo as any);
+	});
+
+	describe('findById', () => {
+		it('returns the request when found', async () => {
+			const request = { id: 'req-1' } as ContactRequest;
+			mockTypeormRepo.findOne.mockResolvedValue(request);
+
+			const result = await repo.findById('req-1');
+
+			expect(mockTypeormRepo.findOne).toHaveBeenCalledWith({ where: { id: 'req-1' } });
+			expect(result).toBe(request);
+		});
+
+		it('returns null when not found', async () => {
+			mockTypeormRepo.findOne.mockResolvedValue(null);
+
+			const result = await repo.findById('missing');
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('findPendingBetween', () => {
+		it('searches for a pending request in either direction', async () => {
+			const request = { id: 'req-1' } as ContactRequest;
+			mockTypeormRepo.findOne.mockResolvedValue(request);
+
+			const result = await repo.findPendingBetween('user-a', 'user-b');
+
+			expect(mockTypeormRepo.findOne).toHaveBeenCalledWith({
+				where: [
+					{ requesterId: 'user-a', recipientId: 'user-b', status: ContactRequestStatus.PENDING },
+					{ requesterId: 'user-b', recipientId: 'user-a', status: ContactRequestStatus.PENDING },
+				],
+			});
+			expect(result).toBe(request);
+		});
+	});
+
+	describe('findAllForUser', () => {
+		it('returns all requests involving the user with requester and recipient relations', async () => {
+			const requests = [{ id: 'req-1' }] as ContactRequest[];
+			mockTypeormRepo.find.mockResolvedValue(requests);
+
+			const result = await repo.findAllForUser('user-a');
+
+			expect(mockTypeormRepo.find).toHaveBeenCalledWith({
+				where: [{ requesterId: 'user-a' }, { recipientId: 'user-a' }],
+				relations: ['requester', 'recipient'],
+				order: { createdAt: 'DESC' },
+			});
+			expect(result).toBe(requests);
+		});
+	});
+
+	describe('create', () => {
+		it('creates a pending request and saves it', async () => {
+			const draft = {
+				requesterId: 'user-a',
+				recipientId: 'user-b',
+				status: ContactRequestStatus.PENDING,
+			} as ContactRequest;
+			const saved = { id: 'req-1', ...draft } as ContactRequest;
+			mockTypeormRepo.create.mockReturnValue(draft);
+			mockTypeormRepo.save.mockResolvedValue(saved);
+
+			const result = await repo.create('user-a', 'user-b');
+
+			expect(mockTypeormRepo.create).toHaveBeenCalledWith({
+				requesterId: 'user-a',
+				recipientId: 'user-b',
+				status: ContactRequestStatus.PENDING,
+			});
+			expect(mockTypeormRepo.save).toHaveBeenCalledWith(draft);
+			expect(result).toBe(saved);
+		});
+	});
+
+	describe('save', () => {
+		it('delegates to the typeorm save', async () => {
+			const request = { id: 'req-1' } as ContactRequest;
+			mockTypeormRepo.save.mockResolvedValue(request);
+
+			const result = await repo.save(request);
+
+			expect(mockTypeormRepo.save).toHaveBeenCalledWith(request);
+			expect(result).toBe(request);
+		});
+	});
+
+	describe('remove', () => {
+		it('delegates to the typeorm remove', async () => {
+			const request = { id: 'req-1' } as ContactRequest;
+			mockTypeormRepo.remove.mockResolvedValue(request);
+
+			await repo.remove(request);
+
+			expect(mockTypeormRepo.remove).toHaveBeenCalledWith(request);
+		});
+	});
+});

--- a/src/modules/contacts/repositories/contacts.repository.spec.ts
+++ b/src/modules/contacts/repositories/contacts.repository.spec.ts
@@ -1,0 +1,122 @@
+import { ContactsRepository } from './contacts.repository';
+import { Contact } from '../entities/contact.entity';
+
+const mockTypeormRepo = {
+	create: jest.fn(),
+	save: jest.fn(),
+	findOne: jest.fn(),
+	find: jest.fn(),
+	remove: jest.fn(),
+};
+
+describe('ContactsRepository', () => {
+	let repo: ContactsRepository;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		repo = new ContactsRepository(mockTypeormRepo as any);
+	});
+
+	describe('findAllByOwner', () => {
+		it('returns contacts for the owner with the contact relation loaded', async () => {
+			const contacts = [{ id: 'c1' }] as Contact[];
+			mockTypeormRepo.find.mockResolvedValue(contacts);
+
+			const result = await repo.findAllByOwner('owner-1');
+
+			expect(mockTypeormRepo.find).toHaveBeenCalledWith({
+				where: { ownerId: 'owner-1' },
+				relations: ['contact'],
+			});
+			expect(result).toBe(contacts);
+		});
+	});
+
+	describe('findOne', () => {
+		it('returns a contact when found', async () => {
+			const contact = { id: 'c1' } as Contact;
+			mockTypeormRepo.findOne.mockResolvedValue(contact);
+
+			const result = await repo.findOne('owner-1', 'contact-1');
+
+			expect(mockTypeormRepo.findOne).toHaveBeenCalledWith({
+				where: { ownerId: 'owner-1', contactId: 'contact-1' },
+				relations: ['contact'],
+			});
+			expect(result).toBe(contact);
+		});
+
+		it('returns null when not found', async () => {
+			mockTypeormRepo.findOne.mockResolvedValue(null);
+
+			const result = await repo.findOne('owner-1', 'missing');
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('create', () => {
+		it('creates and saves a contact with a nickname, then reloads relations', async () => {
+			const draft = { ownerId: 'owner-1', contactId: 'contact-1', nickname: 'Bob' } as Contact;
+			const saved = { id: 'c1', ...draft } as Contact;
+			const reloaded = { ...saved, contact: { id: 'contact-1' } } as Contact;
+			mockTypeormRepo.create.mockReturnValue(draft);
+			mockTypeormRepo.save.mockResolvedValue(saved);
+			mockTypeormRepo.findOne.mockResolvedValue(reloaded);
+
+			const result = await repo.create('owner-1', 'contact-1', 'Bob');
+
+			expect(mockTypeormRepo.create).toHaveBeenCalledWith({
+				ownerId: 'owner-1',
+				contactId: 'contact-1',
+				nickname: 'Bob',
+			});
+			expect(mockTypeormRepo.save).toHaveBeenCalledWith(draft);
+			expect(mockTypeormRepo.findOne).toHaveBeenCalledWith({
+				where: { id: 'c1' },
+				relations: ['contact'],
+			});
+			expect(result).toBe(reloaded);
+		});
+
+		it('defaults nickname to null when not provided', async () => {
+			const draft = { ownerId: 'owner-1', contactId: 'contact-1', nickname: null } as Contact;
+			const saved = { id: 'c1', ...draft } as Contact;
+			mockTypeormRepo.create.mockReturnValue(draft);
+			mockTypeormRepo.save.mockResolvedValue(saved);
+			mockTypeormRepo.findOne.mockResolvedValue(null);
+
+			const result = await repo.create('owner-1', 'contact-1');
+
+			expect(mockTypeormRepo.create).toHaveBeenCalledWith({
+				ownerId: 'owner-1',
+				contactId: 'contact-1',
+				nickname: null,
+			});
+			expect(result).toBe(saved);
+		});
+	});
+
+	describe('save', () => {
+		it('delegates to the typeorm save', async () => {
+			const contact = { id: 'c1' } as Contact;
+			mockTypeormRepo.save.mockResolvedValue(contact);
+
+			const result = await repo.save(contact);
+
+			expect(mockTypeormRepo.save).toHaveBeenCalledWith(contact);
+			expect(result).toBe(contact);
+		});
+	});
+
+	describe('remove', () => {
+		it('delegates to the typeorm remove', async () => {
+			const contact = { id: 'c1' } as Contact;
+			mockTypeormRepo.remove.mockResolvedValue(contact);
+
+			await repo.remove(contact);
+
+			expect(mockTypeormRepo.remove).toHaveBeenCalledWith(contact);
+		});
+	});
+});

--- a/src/modules/groups/controllers/groups.controller.spec.ts
+++ b/src/modules/groups/controllers/groups.controller.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupsController } from './groups.controller';
+import { GroupsService } from '../services/groups.service';
+import { Group } from '../entities/group.entity';
+import { CreateGroupDto } from '../dto/create-group.dto';
+import { UpdateGroupDto } from '../dto/update-group.dto';
+
+describe('GroupsController', () => {
+	let controller: GroupsController;
+	let service: jest.Mocked<GroupsService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [GroupsController],
+			providers: [
+				{
+					provide: GroupsService,
+					useValue: {
+						getGroups: jest.fn(),
+						createGroup: jest.fn(),
+						updateGroup: jest.fn(),
+						deleteGroup: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		controller = module.get<GroupsController>(GroupsController);
+		service = module.get(GroupsService);
+	});
+
+	describe('getGroups', () => {
+		it('delegates to the service', async () => {
+			const groups = [{ id: 'g1' }] as Group[];
+			service.getGroups.mockResolvedValue(groups);
+
+			const result = await controller.getGroups('owner-1');
+
+			expect(result).toBe(groups);
+			expect(service.getGroups).toHaveBeenCalledWith('owner-1');
+		});
+	});
+
+	describe('createGroup', () => {
+		it('delegates to the service', async () => {
+			const dto: CreateGroupDto = { name: 'Friends' } as CreateGroupDto;
+			const created = { id: 'g1' } as Group;
+			service.createGroup.mockResolvedValue(created);
+
+			const result = await controller.createGroup('owner-1', dto);
+
+			expect(result).toBe(created);
+			expect(service.createGroup).toHaveBeenCalledWith('owner-1', dto);
+		});
+	});
+
+	describe('updateGroup', () => {
+		it('delegates to the service', async () => {
+			const dto: UpdateGroupDto = { name: 'Family' } as UpdateGroupDto;
+			const updated = { id: 'g1', name: 'Family' } as Group;
+			service.updateGroup.mockResolvedValue(updated);
+
+			const result = await controller.updateGroup('owner-1', 'g1', dto);
+
+			expect(result).toBe(updated);
+			expect(service.updateGroup).toHaveBeenCalledWith('owner-1', 'g1', dto);
+		});
+	});
+
+	describe('deleteGroup', () => {
+		it('delegates to the service', async () => {
+			service.deleteGroup.mockResolvedValue(undefined);
+
+			await controller.deleteGroup('owner-1', 'g1');
+
+			expect(service.deleteGroup).toHaveBeenCalledWith('owner-1', 'g1');
+		});
+	});
+});

--- a/src/modules/groups/repositories/groups.repository.spec.ts
+++ b/src/modules/groups/repositories/groups.repository.spec.ts
@@ -1,0 +1,121 @@
+import { GroupsRepository } from './groups.repository';
+import { Group } from '../entities/group.entity';
+
+const mockTypeormRepo = {
+	create: jest.fn(),
+	save: jest.fn(),
+	findOne: jest.fn(),
+	find: jest.fn(),
+	remove: jest.fn(),
+};
+
+describe('GroupsRepository', () => {
+	let repo: GroupsRepository;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		repo = new GroupsRepository(mockTypeormRepo as any);
+	});
+
+	describe('findAllByOwner', () => {
+		it('returns groups owned by the user', async () => {
+			const groups = [{ id: 'g1' }] as Group[];
+			mockTypeormRepo.find.mockResolvedValue(groups);
+
+			const result = await repo.findAllByOwner('owner-1');
+
+			expect(mockTypeormRepo.find).toHaveBeenCalledWith({ where: { ownerId: 'owner-1' } });
+			expect(result).toBe(groups);
+		});
+	});
+
+	describe('findOneById', () => {
+		it('returns a group by its id', async () => {
+			const group = { id: 'g1' } as Group;
+			mockTypeormRepo.findOne.mockResolvedValue(group);
+
+			const result = await repo.findOneById('g1');
+
+			expect(mockTypeormRepo.findOne).toHaveBeenCalledWith({ where: { id: 'g1' } });
+			expect(result).toBe(group);
+		});
+
+		it('returns null when not found', async () => {
+			mockTypeormRepo.findOne.mockResolvedValue(null);
+
+			const result = await repo.findOneById('missing');
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('findOneByOwnerAndId', () => {
+		it('scopes the lookup to the owner and id', async () => {
+			const group = { id: 'g1' } as Group;
+			mockTypeormRepo.findOne.mockResolvedValue(group);
+
+			const result = await repo.findOneByOwnerAndId('owner-1', 'g1');
+
+			expect(mockTypeormRepo.findOne).toHaveBeenCalledWith({
+				where: { ownerId: 'owner-1', id: 'g1' },
+			});
+			expect(result).toBe(group);
+		});
+	});
+
+	describe('create', () => {
+		it('creates and saves a group with a description', async () => {
+			const draft = { ownerId: 'owner-1', name: 'Friends', description: 'IRL' } as Group;
+			const saved = { id: 'g1', ...draft } as Group;
+			mockTypeormRepo.create.mockReturnValue(draft);
+			mockTypeormRepo.save.mockResolvedValue(saved);
+
+			const result = await repo.create('owner-1', 'Friends', 'IRL');
+
+			expect(mockTypeormRepo.create).toHaveBeenCalledWith({
+				ownerId: 'owner-1',
+				name: 'Friends',
+				description: 'IRL',
+			});
+			expect(mockTypeormRepo.save).toHaveBeenCalledWith(draft);
+			expect(result).toBe(saved);
+		});
+
+		it('defaults description to null when not provided', async () => {
+			const draft = { ownerId: 'owner-1', name: 'Friends', description: null } as Group;
+			mockTypeormRepo.create.mockReturnValue(draft);
+			mockTypeormRepo.save.mockResolvedValue(draft);
+
+			await repo.create('owner-1', 'Friends');
+
+			expect(mockTypeormRepo.create).toHaveBeenCalledWith({
+				ownerId: 'owner-1',
+				name: 'Friends',
+				description: null,
+			});
+		});
+	});
+
+	describe('save', () => {
+		it('delegates to the typeorm save', async () => {
+			const group = { id: 'g1' } as Group;
+			mockTypeormRepo.save.mockResolvedValue(group);
+
+			const result = await repo.save(group);
+
+			expect(mockTypeormRepo.save).toHaveBeenCalledWith(group);
+			expect(result).toBe(group);
+		});
+	});
+
+	describe('remove', () => {
+		it('delegates to the typeorm remove', async () => {
+			const group = { id: 'g1' } as Group;
+			mockTypeormRepo.remove.mockResolvedValue(group);
+
+			await repo.remove(group);
+
+			expect(mockTypeormRepo.remove).toHaveBeenCalledWith(group);
+		});
+	});
+});

--- a/src/modules/privacy/controllers/privacy.controller.spec.ts
+++ b/src/modules/privacy/controllers/privacy.controller.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrivacyController } from './privacy.controller';
+import { PrivacyService } from '../services/privacy.service';
+import { PrivacySettings } from '../entities/privacy-settings.entity';
+import { UpdatePrivacySettingsDto } from '../dto/update-privacy-settings.dto';
+
+describe('PrivacyController', () => {
+	let controller: PrivacyController;
+	let service: jest.Mocked<PrivacyService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [PrivacyController],
+			providers: [
+				{
+					provide: PrivacyService,
+					useValue: {
+						getSettings: jest.fn(),
+						updateSettings: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		controller = module.get<PrivacyController>(PrivacyController);
+		service = module.get(PrivacyService);
+	});
+
+	describe('getSettings', () => {
+		it('delegates to the service', async () => {
+			const settings = { userId: 'user-1' } as PrivacySettings;
+			service.getSettings.mockResolvedValue(settings);
+
+			const result = await controller.getSettings('user-1');
+
+			expect(result).toBe(settings);
+			expect(service.getSettings).toHaveBeenCalledWith('user-1');
+		});
+	});
+
+	describe('updateSettings', () => {
+		it('delegates to the service', async () => {
+			const dto: UpdatePrivacySettingsDto = {} as UpdatePrivacySettingsDto;
+			const updated = { userId: 'user-1' } as PrivacySettings;
+			service.updateSettings.mockResolvedValue(updated);
+
+			const result = await controller.updateSettings('user-1', dto);
+
+			expect(result).toBe(updated);
+			expect(service.updateSettings).toHaveBeenCalledWith('user-1', dto);
+		});
+	});
+});

--- a/src/modules/privacy/repositories/privacy-settings.repository.spec.ts
+++ b/src/modules/privacy/repositories/privacy-settings.repository.spec.ts
@@ -1,0 +1,77 @@
+import { PrivacySettingsRepository } from './privacy-settings.repository';
+import { PrivacySettings, PrivacyLevel, MediaAutoDownload } from '../entities/privacy-settings.entity';
+
+const mockTypeormRepo = {
+	create: jest.fn(),
+	save: jest.fn(),
+	findOne: jest.fn(),
+};
+
+describe('PrivacySettingsRepository', () => {
+	let repo: PrivacySettingsRepository;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		repo = new PrivacySettingsRepository(mockTypeormRepo as any);
+	});
+
+	describe('findByUserId', () => {
+		it('returns the settings when found', async () => {
+			const settings = { userId: 'user-1' } as PrivacySettings;
+			mockTypeormRepo.findOne.mockResolvedValue(settings);
+
+			const result = await repo.findByUserId('user-1');
+
+			expect(mockTypeormRepo.findOne).toHaveBeenCalledWith({ where: { userId: 'user-1' } });
+			expect(result).toBe(settings);
+		});
+
+		it('returns null when not found', async () => {
+			mockTypeormRepo.findOne.mockResolvedValue(null);
+
+			const result = await repo.findByUserId('missing');
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('createDefault', () => {
+		it('creates settings with the documented defaults', async () => {
+			const draft = { userId: 'user-1' } as PrivacySettings;
+			const saved = { id: 'ps-1', ...draft } as PrivacySettings;
+			mockTypeormRepo.create.mockReturnValue(draft);
+			mockTypeormRepo.save.mockResolvedValue(saved);
+
+			const result = await repo.createDefault('user-1');
+
+			expect(mockTypeormRepo.create).toHaveBeenCalledWith({
+				userId: 'user-1',
+				profilePicturePrivacy: PrivacyLevel.EVERYONE,
+				firstNamePrivacy: PrivacyLevel.EVERYONE,
+				lastNamePrivacy: PrivacyLevel.CONTACTS,
+				biographyPrivacy: PrivacyLevel.EVERYONE,
+				lastSeenPrivacy: PrivacyLevel.CONTACTS,
+				searchByPhone: true,
+				searchByUsername: true,
+				readReceipts: true,
+				onlineStatus: PrivacyLevel.CONTACTS,
+				groupAddPermission: PrivacyLevel.CONTACTS,
+				mediaAutoDownload: MediaAutoDownload.WIFI_ONLY,
+			});
+			expect(mockTypeormRepo.save).toHaveBeenCalledWith(draft);
+			expect(result).toBe(saved);
+		});
+	});
+
+	describe('save', () => {
+		it('delegates to the typeorm save', async () => {
+			const settings = { userId: 'user-1' } as PrivacySettings;
+			mockTypeormRepo.save.mockResolvedValue(settings);
+
+			const result = await repo.save(settings);
+
+			expect(mockTypeormRepo.save).toHaveBeenCalledWith(settings);
+			expect(result).toBe(settings);
+		});
+	});
+});

--- a/src/modules/profile/controllers/profile.controller.spec.ts
+++ b/src/modules/profile/controllers/profile.controller.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import type { Request as ExpressRequest } from 'express';
+import { ProfileController } from './profile.controller';
+import { ProfileService } from '../services/profile.service';
+import { User } from '../../common/entities/user.entity';
+import { UpdateProfileDto } from '../dto/update-profile.dto';
+import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+
+const makeReq = (sub: string, authorization?: string): ExpressRequest & { user: JwtPayload } =>
+	({
+		user: { sub } as JwtPayload,
+		headers: authorization ? { authorization } : {},
+	}) as unknown as ExpressRequest & { user: JwtPayload };
+
+describe('ProfileController', () => {
+	let controller: ProfileController;
+	let service: jest.Mocked<ProfileService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [ProfileController],
+			providers: [
+				{
+					provide: ProfileService,
+					useValue: {
+						getProfile: jest.fn(),
+						updateProfile: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		controller = module.get<ProfileController>(ProfileController);
+		service = module.get(ProfileService);
+	});
+
+	describe('getProfile', () => {
+		it('delegates to the service', async () => {
+			const user = { id: 'user-1' } as User;
+			service.getProfile.mockResolvedValue(user);
+
+			const result = await controller.getProfile('user-1');
+
+			expect(result).toBe(user);
+			expect(service.getProfile).toHaveBeenCalledWith('user-1');
+		});
+	});
+
+	describe('updateProfile', () => {
+		it('updates the profile when the caller is the owner and forwards the authorization header', async () => {
+			const dto: UpdateProfileDto = { username: 'alice' } as UpdateProfileDto;
+			const updated = { id: 'user-1' } as User;
+			service.updateProfile.mockResolvedValue(updated);
+
+			const result = await controller.updateProfile('user-1', dto, makeReq('user-1', 'Bearer token'));
+
+			expect(result).toBe(updated);
+			expect(service.updateProfile).toHaveBeenCalledWith('user-1', dto, 'Bearer token');
+		});
+
+		it('passes undefined authorization when the header is missing', async () => {
+			const dto: UpdateProfileDto = {} as UpdateProfileDto;
+			const updated = { id: 'user-1' } as User;
+			service.updateProfile.mockResolvedValue(updated);
+
+			await controller.updateProfile('user-1', dto, makeReq('user-1'));
+
+			expect(service.updateProfile).toHaveBeenCalledWith('user-1', dto, undefined);
+		});
+
+		it('throws Forbidden when the caller targets another user', async () => {
+			await expect(
+				controller.updateProfile('user-1', {} as UpdateProfileDto, makeReq('other'))
+			).rejects.toThrow(ForbiddenException);
+			expect(service.updateProfile).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/modules/search/controllers/user-search.controller.spec.ts
+++ b/src/modules/search/controllers/user-search.controller.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserSearchController } from './user-search.controller';
+import { UserSearchService, UserSearchResult } from '../services/user-search.service';
+import { User } from '../../common/entities/user.entity';
+import { BatchPhoneSearchDto } from '../dto/batch-phone-search.dto';
+
+describe('UserSearchController', () => {
+	let controller: UserSearchController;
+	let service: jest.Mocked<UserSearchService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [UserSearchController],
+			providers: [
+				{
+					provide: UserSearchService,
+					useValue: {
+						searchByPhone: jest.fn(),
+						searchByPhoneBatch: jest.fn(),
+						searchByUsername: jest.fn(),
+						searchByDisplayName: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		controller = module.get<UserSearchController>(UserSearchController);
+		service = module.get(UserSearchService);
+	});
+
+	describe('searchByPhone', () => {
+		it('delegates to the service', async () => {
+			const user = { id: 'u1' } as User;
+			service.searchByPhone.mockResolvedValue(user);
+
+			const result = await controller.searchByPhone('+33600000000');
+
+			expect(result).toBe(user);
+			expect(service.searchByPhone).toHaveBeenCalledWith('+33600000000');
+		});
+	});
+
+	describe('searchByPhoneBatch', () => {
+		it('forwards the phone numbers from the dto', async () => {
+			const users = [{ id: 'u1' }] as User[];
+			service.searchByPhoneBatch.mockResolvedValue(users);
+			const dto: BatchPhoneSearchDto = { phoneNumbers: ['+33600000000'] } as BatchPhoneSearchDto;
+
+			const result = await controller.searchByPhoneBatch(dto);
+
+			expect(result).toBe(users);
+			expect(service.searchByPhoneBatch).toHaveBeenCalledWith(['+33600000000']);
+		});
+	});
+
+	describe('searchByUsername', () => {
+		it('delegates to the service', async () => {
+			const user = { id: 'u1' } as User;
+			service.searchByUsername.mockResolvedValue(user);
+
+			const result = await controller.searchByUsername('alice');
+
+			expect(result).toBe(user);
+			expect(service.searchByUsername).toHaveBeenCalledWith('alice');
+		});
+	});
+
+	describe('searchByName', () => {
+		it('delegates to the service with the provided limit', async () => {
+			const results: UserSearchResult[] = [
+				{ userId: 'u1', username: 'alice', firstName: 'Alice', lastName: null },
+			];
+			service.searchByDisplayName.mockResolvedValue(results);
+
+			const result = await controller.searchByName('alice', 5);
+
+			expect(result).toBe(results);
+			expect(service.searchByDisplayName).toHaveBeenCalledWith('alice', 5);
+		});
+
+		it('omits the limit when not provided', async () => {
+			service.searchByDisplayName.mockResolvedValue([]);
+
+			await controller.searchByName('alice');
+
+			expect(service.searchByDisplayName).toHaveBeenCalledWith('alice', undefined);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `contacts`, `blocked-users`, `groups`, `privacy`, `profile` and `user-search` controllers (previously 0% coverage)
- Add unit tests for the `contacts`, `contact-requests`, `blocked-users`, `groups` and `privacy-settings` repositories
- Cover `UserRepository.searchByDisplayName` (previously uncovered) and the `UserUpdatedEvent` / `UserDeactivatedEvent` value objects
- All I/O is mocked via jest; no real database or cache is touched

## Why
SonarCloud quality gate on `main` was in ERROR with `new_coverage = 74.2%` (threshold 80%), blocking the post-merge CI (_SonarCloud Quality Gate_ step) and preventing the Docker image from being pushed to the registry. This cascaded into 20+ consecutive CD pipeline failures and a prod deploy halt since ~14:16 UTC on 2026-04-11.

Raising `new_coverage` above 80% unblocks the registry push and lets ArgoCD sync prod again.

## Test plan
- [x] Unit tests green (`npx jest --no-coverage` — 442 tests pass)
- [x] Lint clean (`npx eslint "src/**/*.ts" --fix` + `npx prettier --write`)
- [ ] SonarCloud quality gate OK on the PR (`new_coverage >= 80`)
- [ ] CI Pipeline reaches _Container Registry Push_ step
- [ ] CD Pipeline deploys to prod successfully

Closes WHISPR-790
