### PR TITLE
[WHISPR-812] fix(auth): enforce assertOwnership access control on all user-scoped controllers

### DIFF
--- a/src/modules/accounts/controllers/accounts.controller.spec.ts
+++ b/src/modules/accounts/controllers/accounts.controller.spec.ts
@@ -1,9 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { AccountsController } from './accounts.controller';
 import { AccountsService } from '../services/accounts.service';
 import { UserRegisteredRetryService } from '../services/user-registered-retry.service';
 import { UserRegisteredEvent } from 'src/modules/shared/events';
+
+const makeReq = (sub: string) => ({ user: { sub } }) as any;
 
 const mockAccountsService = (): jest.Mocked<AccountsService> =>
 	({
@@ -59,9 +61,15 @@ describe('AccountsController', () => {
 		it('delegates to accountsService.updateLastSeen', async () => {
 			accountsService.updateLastSeen.mockResolvedValue(undefined);
 
-			await controller.updateLastSeen('uuid-1');
+			await controller.updateLastSeen('uuid-1', makeReq('uuid-1'));
 
 			expect(accountsService.updateLastSeen).toHaveBeenCalledWith('uuid-1');
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			await expect(controller.updateLastSeen('uuid-1', makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 	});
 
@@ -69,15 +77,23 @@ describe('AccountsController', () => {
 		it('delegates to accountsService.deactivate', async () => {
 			accountsService.deactivate.mockResolvedValue(undefined);
 
-			await controller.deactivate('uuid-1');
+			await controller.deactivate('uuid-1', makeReq('uuid-1'));
 
 			expect(accountsService.deactivate).toHaveBeenCalledWith('uuid-1');
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			await expect(controller.deactivate('uuid-1', makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 
 		it('propagates NotFoundException from service', async () => {
 			accountsService.deactivate.mockRejectedValue(new NotFoundException());
 
-			await expect(controller.deactivate('uuid-404')).rejects.toThrow(NotFoundException);
+			await expect(controller.deactivate('uuid-404', makeReq('uuid-404'))).rejects.toThrow(
+				NotFoundException
+			);
 		});
 	});
 
@@ -85,15 +101,23 @@ describe('AccountsController', () => {
 		it('delegates to accountsService.activate', async () => {
 			accountsService.activate.mockResolvedValue(undefined);
 
-			await controller.activate('uuid-1');
+			await controller.activate('uuid-1', makeReq('uuid-1'));
 
 			expect(accountsService.activate).toHaveBeenCalledWith('uuid-1');
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			await expect(controller.activate('uuid-1', makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 
 		it('propagates NotFoundException from service', async () => {
 			accountsService.activate.mockRejectedValue(new NotFoundException());
 
-			await expect(controller.activate('uuid-404')).rejects.toThrow(NotFoundException);
+			await expect(controller.activate('uuid-404', makeReq('uuid-404'))).rejects.toThrow(
+				NotFoundException
+			);
 		});
 	});
 
@@ -101,15 +125,23 @@ describe('AccountsController', () => {
 		it('delegates to accountsService.remove', async () => {
 			accountsService.remove.mockResolvedValue(undefined);
 
-			await controller.remove('uuid-1');
+			await controller.remove('uuid-1', makeReq('uuid-1'));
 
 			expect(accountsService.remove).toHaveBeenCalledWith('uuid-1');
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			await expect(controller.remove('uuid-1', makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 
 		it('propagates NotFoundException from service', async () => {
 			accountsService.remove.mockRejectedValue(new NotFoundException());
 
-			await expect(controller.remove('uuid-404')).rejects.toThrow(NotFoundException);
+			await expect(controller.remove('uuid-404', makeReq('uuid-404'))).rejects.toThrow(
+				NotFoundException
+			);
 		});
 	});
 });

--- a/src/modules/accounts/controllers/accounts.controller.ts
+++ b/src/modules/accounts/controllers/accounts.controller.ts
@@ -9,6 +9,7 @@ import {
 	ParseUUIDPipe,
 	Patch,
 	Post,
+	Request,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
 import { AccountsService } from '../services/accounts.service';
@@ -17,6 +18,9 @@ import { EventPattern, Payload } from '@nestjs/microservices';
 import { USER_REGISTERED_PATTERN, UserRegisteredEvent } from '../../shared/events';
 import { Public } from '../../jwt-auth/public.decorator';
 import { IsString, IsUUID } from 'class-validator';
+import type { Request as ExpressRequest } from 'express';
+import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 class BootstrapAccountDto {
 	@IsUUID()
@@ -84,7 +88,11 @@ export class AccountsController {
 	@ApiResponse({ status: HttpStatus.OK, description: 'Last seen updated successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async updateLastSeen(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+	async updateLastSeen(
+		@Param('id', ParseUUIDPipe) id: string,
+		@Request() req: ExpressRequest & { user: JwtPayload }
+	): Promise<void> {
+		assertOwnership(req, id);
 		return this.accountsService.updateLastSeen(id);
 	}
 
@@ -97,7 +105,11 @@ export class AccountsController {
 	@ApiResponse({ status: HttpStatus.OK, description: 'User deactivated successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async deactivate(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+	async deactivate(
+		@Param('id', ParseUUIDPipe) id: string,
+		@Request() req: ExpressRequest & { user: JwtPayload }
+	): Promise<void> {
+		assertOwnership(req, id);
 		return this.accountsService.deactivate(id);
 	}
 
@@ -110,7 +122,11 @@ export class AccountsController {
 	@ApiResponse({ status: HttpStatus.OK, description: 'User activated successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async activate(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+	async activate(
+		@Param('id', ParseUUIDPipe) id: string,
+		@Request() req: ExpressRequest & { user: JwtPayload }
+	): Promise<void> {
+		assertOwnership(req, id);
 		return this.accountsService.activate(id);
 	}
 
@@ -124,7 +140,11 @@ export class AccountsController {
 	@ApiResponse({ status: HttpStatus.OK, description: 'User deleted successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+	async remove(
+		@Param('id', ParseUUIDPipe) id: string,
+		@Request() req: ExpressRequest & { user: JwtPayload }
+	): Promise<void> {
+		assertOwnership(req, id);
 		return this.accountsService.remove(id);
 	}
 }

--- a/src/modules/blocked-users/controllers/blocked-users.controller.spec.ts
+++ b/src/modules/blocked-users/controllers/blocked-users.controller.spec.ts
@@ -1,8 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
 import { BlockedUsersController } from './blocked-users.controller';
 import { BlockedUsersService } from '../services/blocked-users.service';
 import { BlockedUser } from '../entities/blocked-user.entity';
 import { BlockUserDto } from '../dto/block-user.dto';
+
+const makeReq = (sub: string) => ({ user: { sub } }) as any;
 
 describe('BlockedUsersController', () => {
 	let controller: BlockedUsersController;
@@ -32,10 +35,16 @@ describe('BlockedUsersController', () => {
 			const rows = [{ id: 'b1' }] as BlockedUser[];
 			service.getBlockedUsers.mockResolvedValue(rows);
 
-			const result = await controller.getBlockedUsers('blocker-1');
+			const result = await controller.getBlockedUsers('blocker-1', makeReq('blocker-1'));
 
 			expect(result).toBe(rows);
 			expect(service.getBlockedUsers).toHaveBeenCalledWith('blocker-1');
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			await expect(controller.getBlockedUsers('blocker-1', makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 	});
 
@@ -45,10 +54,17 @@ describe('BlockedUsersController', () => {
 			const created = { id: 'b1' } as BlockedUser;
 			service.blockUser.mockResolvedValue(created);
 
-			const result = await controller.blockUser('blocker-1', dto);
+			const result = await controller.blockUser('blocker-1', dto, makeReq('blocker-1'));
 
 			expect(result).toBe(created);
 			expect(service.blockUser).toHaveBeenCalledWith('blocker-1', dto);
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			const dto: BlockUserDto = { blockedId: 'blocked-1' } as BlockUserDto;
+			await expect(controller.blockUser('blocker-1', dto, makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 	});
 
@@ -56,9 +72,15 @@ describe('BlockedUsersController', () => {
 		it('delegates to the service', async () => {
 			service.unblockUser.mockResolvedValue(undefined);
 
-			await controller.unblockUser('blocker-1', 'blocked-1');
+			await controller.unblockUser('blocker-1', 'blocked-1', makeReq('blocker-1'));
 
 			expect(service.unblockUser).toHaveBeenCalledWith('blocker-1', 'blocked-1');
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			await expect(
+				controller.unblockUser('blocker-1', 'blocked-1', makeReq('attacker'))
+			).rejects.toThrow(ForbiddenException);
 		});
 	});
 });

--- a/src/modules/blocked-users/controllers/blocked-users.controller.ts
+++ b/src/modules/blocked-users/controllers/blocked-users.controller.ts
@@ -8,11 +8,15 @@ import {
 	ParseUUIDPipe,
 	HttpCode,
 	HttpStatus,
+	Request,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
 import { BlockedUsersService } from '../services/blocked-users.service';
 import { BlockUserDto } from '../dto/block-user.dto';
 import { BlockedUser } from '../entities/blocked-user.entity';
+import type { Request as ExpressRequest } from 'express';
+import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Blocked Users')
 @ApiBearerAuth()
@@ -25,7 +29,11 @@ export class BlockedUsersController {
 	@ApiParam({ name: 'blockerId', type: 'string', format: 'uuid', description: 'Blocker user ID' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Blocked users retrieved successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
-	async getBlockedUsers(@Param('blockerId', ParseUUIDPipe) blockerId: string): Promise<BlockedUser[]> {
+	async getBlockedUsers(
+		@Param('blockerId', ParseUUIDPipe) blockerId: string,
+		@Request() req: ExpressRequest & { user: JwtPayload }
+	): Promise<BlockedUser[]> {
+		assertOwnership(req, blockerId);
 		return this.blockedUsersService.getBlockedUsers(blockerId);
 	}
 
@@ -38,8 +46,10 @@ export class BlockedUsersController {
 	@ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Cannot block yourself' })
 	async blockUser(
 		@Param('blockerId', ParseUUIDPipe) blockerId: string,
-		@Body() dto: BlockUserDto
+		@Body() dto: BlockUserDto,
+		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<BlockedUser> {
+		assertOwnership(req, blockerId);
 		return this.blockedUsersService.blockUser(blockerId, dto);
 	}
 
@@ -52,8 +62,10 @@ export class BlockedUsersController {
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User or blocked entry not found' })
 	async unblockUser(
 		@Param('blockerId', ParseUUIDPipe) blockerId: string,
-		@Param('blockedId', ParseUUIDPipe) blockedId: string
+		@Param('blockedId', ParseUUIDPipe) blockedId: string,
+		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<void> {
+		assertOwnership(req, blockerId);
 		return this.blockedUsersService.unblockUser(blockerId, blockedId);
 	}
 }

--- a/src/modules/contacts/controllers/contact-requests.controller.ts
+++ b/src/modules/contacts/controllers/contact-requests.controller.ts
@@ -56,7 +56,7 @@ export class ContactRequestsController {
 		@Param('userId', ParseUUIDPipe) userId: string,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<ContactRequest[]> {
-		assertOwnership(req, userId);
+		assertOwnership(req, userId, "Cannot access another user's contact requests");
 		return this.contactRequestsService.getRequestsForUser(userId);
 	}
 

--- a/src/modules/contacts/controllers/contact-requests.controller.ts
+++ b/src/modules/contacts/controllers/contact-requests.controller.ts
@@ -1,6 +1,5 @@
 import {
 	Controller,
-	ForbiddenException,
 	Get,
 	Post,
 	Patch,
@@ -18,12 +17,7 @@ import { ContactRequestsService } from '../services/contact-requests.service';
 import { SendContactRequestDto } from '../dto/send-contact-request.dto';
 import { ContactRequest } from '../entities/contact-request.entity';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
-
-function assertOwnership(req: ExpressRequest & { user?: JwtPayload }, ownerId: string): void {
-	if (req.user?.sub !== ownerId) {
-		throw new ForbiddenException("Cannot access another user's contact requests");
-	}
-}
+import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Contact Requests')
 @ApiBearerAuth()

--- a/src/modules/contacts/controllers/contacts.controller.ts
+++ b/src/modules/contacts/controllers/contacts.controller.ts
@@ -37,7 +37,7 @@ export class ContactsController {
 		@Param('ownerId', ParseUUIDPipe) ownerId: string,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<Contact[]> {
-		assertOwnership(req, ownerId);
+		assertOwnership(req, ownerId, "Cannot access another user's contacts");
 		return this.contactsService.getContacts(ownerId);
 	}
 
@@ -55,7 +55,7 @@ export class ContactsController {
 		@Body() dto: AddContactDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<Contact> {
-		assertOwnership(req, ownerId);
+		assertOwnership(req, ownerId, "Cannot access another user's contacts");
 		return this.contactsService.addContact(ownerId, dto);
 	}
 
@@ -73,7 +73,7 @@ export class ContactsController {
 		@Body() dto: UpdateContactDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<Contact> {
-		assertOwnership(req, ownerId);
+		assertOwnership(req, ownerId, "Cannot access another user's contacts");
 		return this.contactsService.updateContact(ownerId, contactId, dto);
 	}
 
@@ -91,7 +91,7 @@ export class ContactsController {
 		@Param('contactId', ParseUUIDPipe) contactId: string,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<void> {
-		assertOwnership(req, ownerId);
+		assertOwnership(req, ownerId, "Cannot access another user's contacts");
 		return this.contactsService.removeContact(ownerId, contactId);
 	}
 }

--- a/src/modules/contacts/controllers/contacts.controller.ts
+++ b/src/modules/contacts/controllers/contacts.controller.ts
@@ -1,6 +1,5 @@
 import {
 	Controller,
-	ForbiddenException,
 	Get,
 	Post,
 	Patch,
@@ -19,12 +18,7 @@ import { AddContactDto } from '../dto/add-contact.dto';
 import { UpdateContactDto } from '../dto/update-contact.dto';
 import { Contact } from '../entities/contact.entity';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
-
-function assertOwnership(req: ExpressRequest & { user?: JwtPayload }, ownerId: string): void {
-	if (req.user?.sub !== ownerId) {
-		throw new ForbiddenException("Cannot access another user's contacts");
-	}
-}
+import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Contacts')
 @ApiBearerAuth()

--- a/src/modules/groups/controllers/groups.controller.spec.ts
+++ b/src/modules/groups/controllers/groups.controller.spec.ts
@@ -1,9 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
 import { GroupsController } from './groups.controller';
 import { GroupsService } from '../services/groups.service';
 import { Group } from '../entities/group.entity';
 import { CreateGroupDto } from '../dto/create-group.dto';
 import { UpdateGroupDto } from '../dto/update-group.dto';
+
+const makeReq = (sub: string) => ({ user: { sub } }) as any;
 
 describe('GroupsController', () => {
 	let controller: GroupsController;
@@ -34,10 +37,16 @@ describe('GroupsController', () => {
 			const groups = [{ id: 'g1' }] as Group[];
 			service.getGroups.mockResolvedValue(groups);
 
-			const result = await controller.getGroups('owner-1');
+			const result = await controller.getGroups('owner-1', makeReq('owner-1'));
 
 			expect(result).toBe(groups);
 			expect(service.getGroups).toHaveBeenCalledWith('owner-1');
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			await expect(controller.getGroups('owner-1', makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 	});
 
@@ -47,10 +56,17 @@ describe('GroupsController', () => {
 			const created = { id: 'g1' } as Group;
 			service.createGroup.mockResolvedValue(created);
 
-			const result = await controller.createGroup('owner-1', dto);
+			const result = await controller.createGroup('owner-1', dto, makeReq('owner-1'));
 
 			expect(result).toBe(created);
 			expect(service.createGroup).toHaveBeenCalledWith('owner-1', dto);
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			const dto: CreateGroupDto = { name: 'Friends' } as CreateGroupDto;
+			await expect(controller.createGroup('owner-1', dto, makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 	});
 
@@ -60,10 +76,17 @@ describe('GroupsController', () => {
 			const updated = { id: 'g1', name: 'Family' } as Group;
 			service.updateGroup.mockResolvedValue(updated);
 
-			const result = await controller.updateGroup('owner-1', 'g1', dto);
+			const result = await controller.updateGroup('owner-1', 'g1', dto, makeReq('owner-1'));
 
 			expect(result).toBe(updated);
 			expect(service.updateGroup).toHaveBeenCalledWith('owner-1', 'g1', dto);
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			const dto: UpdateGroupDto = { name: 'Family' } as UpdateGroupDto;
+			await expect(controller.updateGroup('owner-1', 'g1', dto, makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 	});
 
@@ -71,9 +94,15 @@ describe('GroupsController', () => {
 		it('delegates to the service', async () => {
 			service.deleteGroup.mockResolvedValue(undefined);
 
-			await controller.deleteGroup('owner-1', 'g1');
+			await controller.deleteGroup('owner-1', 'g1', makeReq('owner-1'));
 
 			expect(service.deleteGroup).toHaveBeenCalledWith('owner-1', 'g1');
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			await expect(controller.deleteGroup('owner-1', 'g1', makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 	});
 });

--- a/src/modules/groups/controllers/groups.controller.ts
+++ b/src/modules/groups/controllers/groups.controller.ts
@@ -9,12 +9,16 @@ import {
 	ParseUUIDPipe,
 	HttpCode,
 	HttpStatus,
+	Request,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
 import { GroupsService } from '../services/groups.service';
 import { CreateGroupDto } from '../dto/create-group.dto';
 import { UpdateGroupDto } from '../dto/update-group.dto';
 import { Group } from '../entities/group.entity';
+import type { Request as ExpressRequest } from 'express';
+import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Groups')
 @ApiBearerAuth()
@@ -27,7 +31,11 @@ export class GroupsController {
 	@ApiParam({ name: 'ownerId', type: 'string', format: 'uuid', description: 'Owner user ID' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Groups retrieved successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
-	async getGroups(@Param('ownerId', ParseUUIDPipe) ownerId: string): Promise<Group[]> {
+	async getGroups(
+		@Param('ownerId', ParseUUIDPipe) ownerId: string,
+		@Request() req: ExpressRequest & { user: JwtPayload }
+	): Promise<Group[]> {
+		assertOwnership(req, ownerId);
 		return this.groupsService.getGroups(ownerId);
 	}
 
@@ -38,8 +46,10 @@ export class GroupsController {
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	async createGroup(
 		@Param('ownerId', ParseUUIDPipe) ownerId: string,
-		@Body() dto: CreateGroupDto
+		@Body() dto: CreateGroupDto,
+		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<Group> {
+		assertOwnership(req, ownerId);
 		return this.groupsService.createGroup(ownerId, dto);
 	}
 
@@ -53,8 +63,10 @@ export class GroupsController {
 	async updateGroup(
 		@Param('ownerId', ParseUUIDPipe) ownerId: string,
 		@Param('groupId', ParseUUIDPipe) groupId: string,
-		@Body() dto: UpdateGroupDto
+		@Body() dto: UpdateGroupDto,
+		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<Group> {
+		assertOwnership(req, ownerId);
 		return this.groupsService.updateGroup(ownerId, groupId, dto);
 	}
 
@@ -68,8 +80,10 @@ export class GroupsController {
 	@ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'You do not own this group' })
 	async deleteGroup(
 		@Param('ownerId', ParseUUIDPipe) ownerId: string,
-		@Param('groupId', ParseUUIDPipe) groupId: string
+		@Param('groupId', ParseUUIDPipe) groupId: string,
+		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<void> {
+		assertOwnership(req, ownerId);
 		return this.groupsService.deleteGroup(ownerId, groupId);
 	}
 }

--- a/src/modules/jwt-auth/ownership.util.spec.ts
+++ b/src/modules/jwt-auth/ownership.util.spec.ts
@@ -1,0 +1,18 @@
+import { ForbiddenException } from '@nestjs/common';
+import { assertOwnership } from './ownership.util';
+
+describe('assertOwnership', () => {
+	const makeReq = (sub?: string) => ({ user: sub ? { sub } : undefined }) as any;
+
+	it('does not throw when sub matches resourceOwnerId', () => {
+		expect(() => assertOwnership(makeReq('user-1'), 'user-1')).not.toThrow();
+	});
+
+	it('throws ForbiddenException when sub differs from resourceOwnerId', () => {
+		expect(() => assertOwnership(makeReq('user-1'), 'user-2')).toThrow(ForbiddenException);
+	});
+
+	it('throws ForbiddenException when user is undefined', () => {
+		expect(() => assertOwnership({ user: undefined } as any, 'user-1')).toThrow(ForbiddenException);
+	});
+});

--- a/src/modules/jwt-auth/ownership.util.ts
+++ b/src/modules/jwt-auth/ownership.util.ts
@@ -1,0 +1,9 @@
+import { ForbiddenException } from '@nestjs/common';
+import type { Request as ExpressRequest } from 'express';
+import { JwtPayload } from './jwt.strategy';
+
+export function assertOwnership(req: ExpressRequest & { user?: JwtPayload }, resourceOwnerId: string): void {
+	if (req.user?.sub !== resourceOwnerId) {
+		throw new ForbiddenException("Cannot access another user's resources");
+	}
+}

--- a/src/modules/jwt-auth/ownership.util.ts
+++ b/src/modules/jwt-auth/ownership.util.ts
@@ -2,8 +2,12 @@ import { ForbiddenException } from '@nestjs/common';
 import type { Request as ExpressRequest } from 'express';
 import { JwtPayload } from './jwt.strategy';
 
-export function assertOwnership(req: ExpressRequest & { user?: JwtPayload }, resourceOwnerId: string): void {
+export function assertOwnership(
+	req: ExpressRequest & { user?: JwtPayload },
+	resourceOwnerId: string,
+	forbiddenMessage?: string
+): void {
 	if (req.user?.sub !== resourceOwnerId) {
-		throw new ForbiddenException("Cannot access another user's resources");
+		throw new ForbiddenException(forbiddenMessage ?? "Cannot access another user's resources");
 	}
 }

--- a/src/modules/privacy/controllers/privacy.controller.spec.ts
+++ b/src/modules/privacy/controllers/privacy.controller.spec.ts
@@ -1,8 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
 import { PrivacyController } from './privacy.controller';
 import { PrivacyService } from '../services/privacy.service';
 import { PrivacySettings } from '../entities/privacy-settings.entity';
 import { UpdatePrivacySettingsDto } from '../dto/update-privacy-settings.dto';
+
+const makeReq = (sub: string) => ({ user: { sub } }) as any;
 
 describe('PrivacyController', () => {
 	let controller: PrivacyController;
@@ -31,10 +34,16 @@ describe('PrivacyController', () => {
 			const settings = { userId: 'user-1' } as PrivacySettings;
 			service.getSettings.mockResolvedValue(settings);
 
-			const result = await controller.getSettings('user-1');
+			const result = await controller.getSettings('user-1', makeReq('user-1'));
 
 			expect(result).toBe(settings);
 			expect(service.getSettings).toHaveBeenCalledWith('user-1');
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			await expect(controller.getSettings('user-1', makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 	});
 
@@ -44,10 +53,17 @@ describe('PrivacyController', () => {
 			const updated = { userId: 'user-1' } as PrivacySettings;
 			service.updateSettings.mockResolvedValue(updated);
 
-			const result = await controller.updateSettings('user-1', dto);
+			const result = await controller.updateSettings('user-1', dto, makeReq('user-1'));
 
 			expect(result).toBe(updated);
 			expect(service.updateSettings).toHaveBeenCalledWith('user-1', dto);
+		});
+
+		it('throws ForbiddenException when caller is not the owner', async () => {
+			const dto: UpdatePrivacySettingsDto = {} as UpdatePrivacySettingsDto;
+			await expect(controller.updateSettings('user-1', dto, makeReq('attacker'))).rejects.toThrow(
+				ForbiddenException
+			);
 		});
 	});
 });

--- a/src/modules/privacy/controllers/privacy.controller.ts
+++ b/src/modules/privacy/controllers/privacy.controller.ts
@@ -1,8 +1,11 @@
-import { Controller, Get, Patch, Param, Body, ParseUUIDPipe, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Patch, Param, Body, ParseUUIDPipe, HttpStatus, Request } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
 import { PrivacyService } from '../services/privacy.service';
 import { UpdatePrivacySettingsDto } from '../dto/update-privacy-settings.dto';
 import { PrivacySettings } from '../entities/privacy-settings.entity';
+import type { Request as ExpressRequest } from 'express';
+import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Privacy')
 @ApiBearerAuth()
@@ -16,7 +19,11 @@ export class PrivacyController {
 	@ApiResponse({ status: HttpStatus.OK, description: 'Privacy settings retrieved successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async getSettings(@Param('userId', ParseUUIDPipe) userId: string): Promise<PrivacySettings> {
+	async getSettings(
+		@Param('userId', ParseUUIDPipe) userId: string,
+		@Request() req: ExpressRequest & { user: JwtPayload }
+	): Promise<PrivacySettings> {
+		assertOwnership(req, userId);
 		return this.privacyService.getSettings(userId);
 	}
 
@@ -28,8 +35,10 @@ export class PrivacyController {
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async updateSettings(
 		@Param('userId', ParseUUIDPipe) userId: string,
-		@Body() dto: UpdatePrivacySettingsDto
+		@Body() dto: UpdatePrivacySettingsDto,
+		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<PrivacySettings> {
+		assertOwnership(req, userId);
 		return this.privacyService.updateSettings(userId, dto);
 	}
 }

--- a/src/modules/profile/controllers/profile.controller.ts
+++ b/src/modules/profile/controllers/profile.controller.ts
@@ -36,7 +36,7 @@ export class ProfileController {
 		@Body() dto: UpdateProfileDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<User> {
-		assertOwnership(req, id);
+		assertOwnership(req, id, "Cannot update another user's profile");
 		const authorization = (req.headers['authorization'] as string | undefined) ?? undefined;
 		return this.profileService.updateProfile(id, dto, authorization);
 	}

--- a/src/modules/profile/controllers/profile.controller.ts
+++ b/src/modules/profile/controllers/profile.controller.ts
@@ -1,20 +1,11 @@
-import {
-	Controller,
-	ForbiddenException,
-	Get,
-	Patch,
-	Param,
-	Body,
-	ParseUUIDPipe,
-	HttpStatus,
-	Request,
-} from '@nestjs/common';
+import { Controller, Get, Patch, Param, Body, ParseUUIDPipe, HttpStatus, Request } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
 import { ProfileService } from '../services/profile.service';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
 import { User } from '../../common/entities/user.entity';
 import type { Request as ExpressRequest } from 'express';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Profile')
 @ApiBearerAuth()
@@ -45,11 +36,7 @@ export class ProfileController {
 		@Body() dto: UpdateProfileDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<User> {
-		// The JWT sub claim is the authoritative user identity — prevent users from
-		// updating each other's profiles by comparing the route param to the caller.
-		if (req.user?.sub !== id) {
-			throw new ForbiddenException("Cannot update another user's profile");
-		}
+		assertOwnership(req, id);
 		const authorization = (req.headers['authorization'] as string | undefined) ?? undefined;
 		return this.profileService.updateProfile(id, dto, authorization);
 	}


### PR DESCRIPTION
## Summary
- Extract `assertOwnership` into a shared helper (`src/modules/jwt-auth/ownership.util.ts`) that compares the JWT `sub` claim to the route's user ID parameter and throws `ForbiddenException` on mismatch
- Apply `assertOwnership` to all routes on `PrivacyController`, `BlockedUsersController`, `GroupsController`, and `AccountsController` that accept a user ID parameter — closing the IDOR vulnerability
- Consolidate the duplicate `assertOwnership` functions in `ContactsController`, `ContactRequestsController`, and the inline check in `ProfileController` to use the shared helper
- Add unit tests per controller verifying 403 rejection when `req.user.sub !== :id`

## Test plan
- [x] Unit tests green (433 tests, 42 suites)
- [x] E2E tests green (docker stack)
- [x] Lint clean
- [x] Each affected controller has a dedicated `throws ForbiddenException when caller is not the owner` test case

Closes WHISPR-812