### PR TITLE
[WHISPR-816] fix(contacts): replace unique constraint with partial index on pending requests

### DIFF
--- a/src/database/migrations/1775500100000-ReplaceContactRequestUniqueWithPartialIndex.ts
+++ b/src/database/migrations/1775500100000-ReplaceContactRequestUniqueWithPartialIndex.ts
@@ -12,7 +12,7 @@ export class ReplaceContactRequestUniqueWithPartialIndex1775500100000 implements
 		);
 	}
 
-	public async down(): Promise<void> {
+	public async down(_queryRunner: QueryRunner): Promise<void> {
 		throw new Error(
 			'Irreversible migration: the database may now contain multiple contact_requests rows ' +
 				'for the same (requester_id, recipient_id) pair. Restoring the old unique constraint ' +

--- a/src/database/migrations/1775500100000-ReplaceContactRequestUniqueWithPartialIndex.ts
+++ b/src/database/migrations/1775500100000-ReplaceContactRequestUniqueWithPartialIndex.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ReplaceContactRequestUniqueWithPartialIndex1775500100000 implements MigrationInterface {
+	name = 'ReplaceContactRequestUniqueWithPartialIndex1775500100000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`ALTER TABLE "users"."contact_requests" DROP CONSTRAINT "UQ_contact_requests_requester_recipient"`
+		);
+		await queryRunner.query(
+			`CREATE UNIQUE INDEX "UQ_contact_requests_pending" ON "users"."contact_requests" ("requester_id", "recipient_id") WHERE status = 'pending'`
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP INDEX "users"."UQ_contact_requests_pending"`);
+		await queryRunner.query(
+			`ALTER TABLE "users"."contact_requests" ADD CONSTRAINT "UQ_contact_requests_requester_recipient" UNIQUE ("requester_id", "recipient_id")`
+		);
+	}
+}

--- a/src/database/migrations/1775500100000-ReplaceContactRequestUniqueWithPartialIndex.ts
+++ b/src/database/migrations/1775500100000-ReplaceContactRequestUniqueWithPartialIndex.ts
@@ -12,10 +12,11 @@ export class ReplaceContactRequestUniqueWithPartialIndex1775500100000 implements
 		);
 	}
 
-	public async down(queryRunner: QueryRunner): Promise<void> {
-		await queryRunner.query(`DROP INDEX "users"."UQ_contact_requests_pending"`);
-		await queryRunner.query(
-			`ALTER TABLE "users"."contact_requests" ADD CONSTRAINT "UQ_contact_requests_requester_recipient" UNIQUE ("requester_id", "recipient_id")`
+	public async down(): Promise<void> {
+		throw new Error(
+			'Irreversible migration: the database may now contain multiple contact_requests rows ' +
+				'for the same (requester_id, recipient_id) pair. Restoring the old unique constraint ' +
+				'requires manual data cleanup before rollback.'
 		);
 	}
 }

--- a/src/database/migrations/__tests__/ReplaceContactRequestUniqueWithPartialIndex.spec.ts
+++ b/src/database/migrations/__tests__/ReplaceContactRequestUniqueWithPartialIndex.spec.ts
@@ -1,0 +1,36 @@
+import { QueryRunner } from 'typeorm';
+import { ReplaceContactRequestUniqueWithPartialIndex1775500100000 } from '../1775500100000-ReplaceContactRequestUniqueWithPartialIndex';
+
+describe('ReplaceContactRequestUniqueWithPartialIndex1775500100000', () => {
+	let migration: ReplaceContactRequestUniqueWithPartialIndex1775500100000;
+	let queryRunner: QueryRunner;
+
+	beforeEach(() => {
+		migration = new ReplaceContactRequestUniqueWithPartialIndex1775500100000();
+		queryRunner = {
+			query: jest.fn().mockResolvedValue(undefined),
+		} as unknown as QueryRunner;
+	});
+
+	describe('up', () => {
+		it('should drop the old unique constraint and create a partial unique index', async () => {
+			await migration.up(queryRunner);
+
+			expect(queryRunner.query).toHaveBeenCalledTimes(2);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				1,
+				`ALTER TABLE "users"."contact_requests" DROP CONSTRAINT "UQ_contact_requests_requester_recipient"`
+			);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				2,
+				`CREATE UNIQUE INDEX "UQ_contact_requests_pending" ON "users"."contact_requests" ("requester_id", "recipient_id") WHERE status = 'pending'`
+			);
+		});
+	});
+
+	describe('down', () => {
+		it('should throw an error because the migration is irreversible', async () => {
+			await expect(migration.down(queryRunner)).rejects.toThrow('Irreversible migration');
+		});
+	});
+});

--- a/src/modules/contacts/entities/contact-request.entity.ts
+++ b/src/modules/contacts/entities/contact-request.entity.ts
@@ -19,6 +19,10 @@ export enum ContactRequestStatus {
 @Entity({ name: 'contact_requests', schema: 'users' })
 @Index('IDX_contact_requests_recipient_status', ['recipientId', 'status'])
 @Index('IDX_contact_requests_requester_status', ['requesterId', 'status'])
+@Index('UQ_contact_requests_pending', ['requesterId', 'recipientId'], {
+	unique: true,
+	where: `"status" = 'pending'`,
+})
 export class ContactRequest {
 	@PrimaryGeneratedColumn('uuid')
 	id: string;

--- a/src/modules/contacts/entities/contact-request.entity.ts
+++ b/src/modules/contacts/entities/contact-request.entity.ts
@@ -6,7 +6,6 @@ import {
 	UpdateDateColumn,
 	ManyToOne,
 	JoinColumn,
-	Unique,
 	Index,
 } from 'typeorm';
 import { User } from '../../common/entities/user.entity';
@@ -18,7 +17,6 @@ export enum ContactRequestStatus {
 }
 
 @Entity({ name: 'contact_requests', schema: 'users' })
-@Unique('UQ_contact_requests_requester_recipient', ['requesterId', 'recipientId'])
 @Index('IDX_contact_requests_recipient_status', ['recipientId', 'status'])
 @Index('IDX_contact_requests_requester_status', ['requesterId', 'status'])
 export class ContactRequest {

--- a/src/modules/contacts/entities/contact-request.entity.ts
+++ b/src/modules/contacts/entities/contact-request.entity.ts
@@ -21,7 +21,7 @@ export enum ContactRequestStatus {
 @Index('IDX_contact_requests_requester_status', ['requesterId', 'status'])
 @Index('UQ_contact_requests_pending', ['requesterId', 'recipientId'], {
 	unique: true,
-	where: `"status" = 'pending'`,
+	where: `"status" = '${ContactRequestStatus.PENDING}'`,
 })
 export class ContactRequest {
 	@PrimaryGeneratedColumn('uuid')


### PR DESCRIPTION
## Summary
- Replace the absolute unique constraint `(requester_id, recipient_id)` with a partial unique index `WHERE status = 'pending'`
- This allows users to re-send a contact request after a previous one was rejected
- Declare the partial index both in the entity (`@Index` decorator with `where` predicate using `ContactRequestStatus.PENDING`) and in the migration (for existing databases)
- Migration is marked irreversible since rollback requires manual data cleanup

## Test plan
- [x] Unit tests green (437/437)
- [x] E2E tests green (2/2)
- [x] Lint clean

Closes WHISPR-816