### PR TITLE
[WHISPR-818] refactor(cache): remove dead code and KEYS anti-pattern from SearchIndexService

### DIFF
--- a/src/modules/cache/search-index.service.spec.ts
+++ b/src/modules/cache/search-index.service.spec.ts
@@ -6,9 +6,7 @@ const mockCacheService = {
 	pipeline: jest.fn(),
 	get: jest.fn(),
 	hget: jest.fn(),
-	keys: jest.fn(),
 	zrange: jest.fn(),
-	delMany: jest.fn(),
 } as unknown as CacheService;
 
 function makeUser(overrides: Partial<User> = {}): User {
@@ -120,42 +118,13 @@ describe('SearchIndexService', () => {
 	});
 
 	describe('searchByName', () => {
-		it('should return direct zrange results when limit is reached', async () => {
+		it('should return zrange results for the normalized query', async () => {
 			mockCacheService.zrange = jest.fn().mockResolvedValue(['user-1', 'user-2']);
-			mockCacheService.keys = jest.fn().mockResolvedValue([]);
 
-			const result = await service.searchByName('alice', 2);
+			const result = await service.searchByName('Alice', 2);
 
+			expect(mockCacheService.zrange).toHaveBeenCalledWith('search:name:alice', 0, 1);
 			expect(result).toEqual(['user-1', 'user-2']);
-		});
-
-		it('should do partial-match loop when direct results are below limit', async () => {
-			mockCacheService.zrange = jest
-				.fn()
-				.mockResolvedValueOnce(['user-1']) // direct hit
-				.mockResolvedValueOnce(['user-2']); // partial match loop
-			mockCacheService.keys = jest.fn().mockResolvedValue(['search:name:alice-smith']);
-
-			const result = await service.searchByName('alice', 5);
-
-			expect(result).toContain('user-1');
-			expect(result).toContain('user-2');
-		});
-
-		it('should stop partial-match loop when limit is reached', async () => {
-			const directIds = ['u1', 'u2'];
-			mockCacheService.zrange = jest.fn().mockResolvedValue(directIds);
-			mockCacheService.keys = jest
-				.fn()
-				.mockResolvedValue(['search:name:alice-a', 'search:name:alice-b', 'search:name:alice-c']);
-			// Simulate more results when iterating partial keys
-			(mockCacheService.zrange as jest.Mock)
-				.mockResolvedValueOnce(['u1', 'u2']) // first call (direct)
-				.mockResolvedValue(['u3', 'u4']); // subsequent calls
-
-			const result = await service.searchByName('alice', 2);
-
-			expect(result.length).toBeLessThanOrEqual(2);
 		});
 
 		it('should return [] when an error occurs', async () => {
@@ -184,106 +153,6 @@ describe('SearchIndexService', () => {
 			const result = await service.getCachedUser('user-1');
 
 			expect(result).toBeNull();
-		});
-	});
-
-	describe('batchIndexUsers', () => {
-		it('should not call pipeline when users array is empty', async () => {
-			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
-
-			await service.batchIndexUsers([]);
-
-			expect(mockCacheService.pipeline).not.toHaveBeenCalled();
-		});
-
-		it('should call pipeline with commands for each user', async () => {
-			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
-			const users = [
-				makeUser({ id: 'u1', username: 'alice' }),
-				makeUser({ id: 'u2', username: 'bob' }),
-			];
-
-			await service.batchIndexUsers(users);
-
-			expect(mockCacheService.pipeline).toHaveBeenCalledTimes(1);
-			const [commands] = (mockCacheService.pipeline as jest.Mock).mock.calls[0];
-			expect(commands).toContainEqual(['hset', 'search:phone', users[0].phoneNumber, 'u1']);
-			expect(commands).toContainEqual(['hset', 'search:username', 'bob', 'u2']);
-		});
-
-		it('should throw when pipeline fails', async () => {
-			mockCacheService.pipeline = jest.fn().mockRejectedValue(new Error('Redis error'));
-
-			await expect(service.batchIndexUsers([makeUser()])).rejects.toThrow('Redis error');
-		});
-	});
-
-	describe('clearAllIndexes', () => {
-		it('should delete all search and user cache keys', async () => {
-			mockCacheService.keys = jest
-				.fn()
-				.mockResolvedValueOnce(['search:phone', 'search:username'])
-				.mockResolvedValueOnce(['user:cache:u1'])
-				.mockResolvedValueOnce(['search:name:alice']);
-			mockCacheService.delMany = jest.fn().mockResolvedValue(undefined);
-
-			await service.clearAllIndexes();
-
-			expect(mockCacheService.delMany).toHaveBeenCalledWith(
-				expect.arrayContaining([
-					'search:phone',
-					'search:username',
-					'user:cache:u1',
-					'search:name:alice',
-				])
-			);
-		});
-
-		it('should not call delMany when no keys found', async () => {
-			mockCacheService.keys = jest.fn().mockResolvedValue([]);
-			mockCacheService.delMany = jest.fn();
-
-			await service.clearAllIndexes();
-
-			expect(mockCacheService.delMany).not.toHaveBeenCalled();
-		});
-
-		it('should throw when an error occurs', async () => {
-			mockCacheService.keys = jest.fn().mockRejectedValue(new Error('Redis error'));
-
-			await expect(service.clearAllIndexes()).rejects.toThrow('Redis error');
-		});
-	});
-
-	describe('getSearchStats', () => {
-		it('should return counts from cache', async () => {
-			mockCacheService.get = jest.fn().mockResolvedValueOnce(10).mockResolvedValueOnce(5);
-			mockCacheService.keys = jest
-				.fn()
-				.mockResolvedValueOnce(['k1', 'k2', 'k3'])
-				.mockResolvedValueOnce(['c1', 'c2']);
-
-			const result = await service.getSearchStats();
-
-			expect(result).toEqual({
-				totalPhoneIndexes: 10,
-				totalUsernameIndexes: 5,
-				totalNameIndexes: 3,
-				totalCachedUsers: 2,
-			});
-		});
-
-		it('should return zeros when an error occurs', async () => {
-			mockCacheService.get = jest.fn().mockRejectedValue(new Error('Redis error'));
-
-			const result = await service.getSearchStats();
-
-			expect(result).toEqual({
-				totalPhoneIndexes: 0,
-				totalUsernameIndexes: 0,
-				totalNameIndexes: 0,
-				totalCachedUsers: 0,
-			});
 		});
 	});
 });

--- a/src/modules/cache/search-index.service.spec.ts
+++ b/src/modules/cache/search-index.service.spec.ts
@@ -127,6 +127,30 @@ describe('SearchIndexService', () => {
 			expect(result).toEqual(['user-1', 'user-2']);
 		});
 
+		it('should clamp limit to 1 when zero or negative', async () => {
+			mockCacheService.zrange = jest.fn().mockResolvedValue(['user-1']);
+
+			await service.searchByName('Alice', 0);
+
+			expect(mockCacheService.zrange).toHaveBeenCalledWith('search:name:alice', 0, 0);
+		});
+
+		it('should floor fractional limit', async () => {
+			mockCacheService.zrange = jest.fn().mockResolvedValue(['user-1', 'user-2']);
+
+			await service.searchByName('Alice', 2.7);
+
+			expect(mockCacheService.zrange).toHaveBeenCalledWith('search:name:alice', 0, 1);
+		});
+
+		it('should fall back to default limit when NaN', async () => {
+			mockCacheService.zrange = jest.fn().mockResolvedValue([]);
+
+			await service.searchByName('Alice', NaN);
+
+			expect(mockCacheService.zrange).toHaveBeenCalledWith('search:name:alice', 0, 19);
+		});
+
 		it('should return [] when an error occurs', async () => {
 			mockCacheService.zrange = jest.fn().mockRejectedValue(new Error('Redis error'));
 

--- a/src/modules/cache/search-index.service.ts
+++ b/src/modules/cache/search-index.service.ts
@@ -144,7 +144,7 @@ export class SearchIndexService {
 
 	async searchByName(query: string, limit: number = 20): Promise<string[]> {
 		try {
-			const safeLimit = Math.max(1, limit);
+			const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.floor(limit)) : 20;
 			const normalizedQuery = query.toLowerCase().trim();
 
 			const ids = await this.cacheService.zrange(

--- a/src/modules/cache/search-index.service.ts
+++ b/src/modules/cache/search-index.service.ts
@@ -145,28 +145,14 @@ export class SearchIndexService {
 	async searchByName(query: string, limit: number = 20): Promise<string[]> {
 		try {
 			const normalizedQuery = query.toLowerCase().trim();
-			const userIds = new Set<string>();
 
 			const ids = await this.cacheService.zrange(
 				`${this.NAME_INDEX_KEY}:${normalizedQuery}`,
 				0,
 				limit - 1
 			);
-			ids.forEach((id) => userIds.add(id));
 
-			if (userIds.size < limit) {
-				const allNameKeys = await this.cacheService.keys(`${this.NAME_INDEX_KEY}:*`);
-				for (const key of allNameKeys) {
-					const nameFromKey = key.replace(`${this.NAME_INDEX_KEY}:`, '');
-					if (nameFromKey.includes(normalizedQuery) || normalizedQuery.includes(nameFromKey)) {
-						const moreIds = await this.cacheService.zrange(key, 0, limit - 1);
-						moreIds.forEach((id) => userIds.add(id));
-						if (userIds.size >= limit) break;
-					}
-				}
-			}
-
-			return Array.from(userIds).slice(0, limit);
+			return ids;
 		} catch (error) {
 			this.logger.error(`Failed to search by name ${query}:`, error);
 			return [];
@@ -179,109 +165,6 @@ export class SearchIndexService {
 		} catch (error) {
 			this.logger.error(`Failed to get cached user ${userId}:`, error);
 			return null;
-		}
-	}
-
-	async batchIndexUsers(users: User[]): Promise<void> {
-		try {
-			const commands: Array<[string, ...any[]]> = [];
-
-			for (const user of users) {
-				const indexEntry: SearchIndexEntry = {
-					userId: user.id,
-					phoneNumber: user.phoneNumber,
-					username: user.username ?? null,
-					firstName: user.firstName ?? null,
-					lastName: user.lastName ?? null,
-					fullName: `${user.firstName} ${user.lastName}`.toLowerCase().trim(),
-					isActive: user.isActive,
-					createdAt: user.createdAt,
-				};
-
-				commands.push(
-					['hset', this.PHONE_INDEX_KEY, user.phoneNumber, user.id],
-					['hset', this.USERNAME_INDEX_KEY, user.username.toLowerCase(), user.id],
-					[
-						'zadd',
-						`${this.NAME_INDEX_KEY}:${user.firstName.toLowerCase()}`,
-						user.createdAt.getTime(),
-						user.id,
-					],
-					[
-						'zadd',
-						`${this.NAME_INDEX_KEY}:${user.lastName.toLowerCase()}`,
-						user.createdAt.getTime(),
-						user.id,
-					],
-					[
-						'zadd',
-						`${this.NAME_INDEX_KEY}:${indexEntry.fullName}`,
-						user.createdAt.getTime(),
-						user.id,
-					],
-					[
-						'setex',
-						`${this.USER_CACHE_PREFIX}:${user.id}`,
-						this.CACHE_TTL,
-						JSON.stringify(indexEntry),
-					]
-				);
-			}
-
-			if (commands.length > 0) {
-				await this.cacheService.pipeline(commands);
-			}
-			this.logger.debug(`Batch indexed ${users.length} users`);
-		} catch (error) {
-			this.logger.error(`Failed to batch index users:`, error);
-			throw error;
-		}
-	}
-
-	async clearAllIndexes(): Promise<void> {
-		try {
-			const keys = await this.cacheService.keys('search:*');
-			const userCacheKeys = await this.cacheService.keys(`${this.USER_CACHE_PREFIX}:*`);
-			const nameIndexKeys = await this.cacheService.keys(`${this.NAME_INDEX_KEY}:*`);
-			const allKeys = [...keys, ...userCacheKeys, ...nameIndexKeys];
-			if (allKeys.length > 0) {
-				await this.cacheService.delMany(allKeys);
-			}
-			this.logger.warn('Cleared all search indexes');
-		} catch (error) {
-			this.logger.error('Failed to clear search indexes:', error);
-			throw error;
-		}
-	}
-
-	async getSearchStats(): Promise<{
-		totalPhoneIndexes: number;
-		totalUsernameIndexes: number;
-		totalNameIndexes: number;
-		totalCachedUsers: number;
-	}> {
-		try {
-			const [phoneCount, usernameCount, nameIndexKeys, cachedUserKeys] = await Promise.all([
-				this.cacheService.get<number>(`${this.PHONE_INDEX_KEY}:count`).then((v) => v ?? 0),
-				this.cacheService.get<number>(`${this.USERNAME_INDEX_KEY}:count`).then((v) => v ?? 0),
-				this.cacheService.keys(`${this.NAME_INDEX_KEY}:*`),
-				this.cacheService.keys(`${this.USER_CACHE_PREFIX}:*`),
-			]);
-
-			return {
-				totalPhoneIndexes: phoneCount as number,
-				totalUsernameIndexes: usernameCount as number,
-				totalNameIndexes: nameIndexKeys.length,
-				totalCachedUsers: cachedUserKeys.length,
-			};
-		} catch (error) {
-			this.logger.error('Failed to get search stats:', error);
-			return {
-				totalPhoneIndexes: 0,
-				totalUsernameIndexes: 0,
-				totalNameIndexes: 0,
-				totalCachedUsers: 0,
-			};
 		}
 	}
 }

--- a/src/modules/cache/search-index.service.ts
+++ b/src/modules/cache/search-index.service.ts
@@ -144,12 +144,13 @@ export class SearchIndexService {
 
 	async searchByName(query: string, limit: number = 20): Promise<string[]> {
 		try {
+			const safeLimit = Math.max(1, limit);
 			const normalizedQuery = query.toLowerCase().trim();
 
 			const ids = await this.cacheService.zrange(
 				`${this.NAME_INDEX_KEY}:${normalizedQuery}`,
 				0,
-				limit - 1
+				safeLimit - 1
 			);
 
 			return ids;


### PR DESCRIPTION
## Summary\n- Remove `batchIndexUsers` (null crash on nullable fields, never called)\n- Remove `clearAllIndexes` (3x `KEYS` O(N) anti-pattern, never called)\n- Remove `getSearchStats` (never called)\n- Remove `KEYS`-based fallback in `searchByName`, keep only direct `zrange` lookup\n- Remove corresponding dead tests (-10 tests, -252 lines)\n\n## Test plan\n- [x] Unit tests green (427/427)\n- [x] E2E tests green (2/2)\n- [x] Lint clean\n\nCloses WHISPR-818