### PR TITLE
[WHISPR-825] fix(cache): call removeUserFromIndex on profile update, deactivate and remove

### DIFF
--- a/src/modules/accounts/services/accounts.service.spec.ts
+++ b/src/modules/accounts/services/accounts.service.spec.ts
@@ -191,6 +191,16 @@ describe('AccountsService', () => {
 			expect(userRepository.updateStatus).toHaveBeenCalledWith('uuid-1', false);
 		});
 
+		it('removes user from search index on deactivation', async () => {
+			const user = mockUser();
+			userRepository.findById.mockResolvedValue(user);
+			userRepository.updateStatus.mockResolvedValue(undefined);
+
+			await service.deactivate('uuid-1');
+
+			expect(searchIndexService.removeUserFromIndex).toHaveBeenCalledWith(user);
+		});
+
 		it('throws NotFoundException when user does not exist', async () => {
 			userRepository.findById.mockResolvedValue(null);
 
@@ -208,6 +218,16 @@ describe('AccountsService', () => {
 			expect(userRepository.updateStatus).toHaveBeenCalledWith('uuid-1', true);
 		});
 
+		it('re-indexes user in search on activation', async () => {
+			const user = mockUser();
+			userRepository.findById.mockResolvedValue(user);
+			userRepository.updateStatus.mockResolvedValue(undefined);
+
+			await service.activate('uuid-1');
+
+			expect(searchIndexService.indexUser).toHaveBeenCalledWith(user);
+		});
+
 		it('throws NotFoundException when user does not exist', async () => {
 			userRepository.findById.mockResolvedValue(null);
 
@@ -223,6 +243,16 @@ describe('AccountsService', () => {
 			await service.remove('uuid-1');
 
 			expect(userRepository.softDelete).toHaveBeenCalledWith('uuid-1');
+		});
+
+		it('removes user from search index on deletion', async () => {
+			const user = mockUser();
+			userRepository.findById.mockResolvedValue(user);
+			userRepository.softDelete.mockResolvedValue(undefined);
+
+			await service.remove('uuid-1');
+
+			expect(searchIndexService.removeUserFromIndex).toHaveBeenCalledWith(user);
 		});
 
 		it('throws NotFoundException when user does not exist', async () => {

--- a/src/modules/accounts/services/accounts.service.spec.ts
+++ b/src/modules/accounts/services/accounts.service.spec.ts
@@ -201,6 +201,15 @@ describe('AccountsService', () => {
 			expect(searchIndexService.removeUserFromIndex).toHaveBeenCalledWith(user);
 		});
 
+		it('still deactivates when Redis removeUserFromIndex fails', async () => {
+			userRepository.findById.mockResolvedValue(mockUser());
+			userRepository.updateStatus.mockResolvedValue(undefined);
+			searchIndexService.removeUserFromIndex.mockRejectedValueOnce(new Error('Redis down'));
+
+			await expect(service.deactivate('uuid-1')).resolves.toBeUndefined();
+			expect(userRepository.updateStatus).toHaveBeenCalledWith('uuid-1', false);
+		});
+
 		it('throws NotFoundException when user does not exist', async () => {
 			userRepository.findById.mockResolvedValue(null);
 
@@ -230,6 +239,16 @@ describe('AccountsService', () => {
 			);
 		});
 
+		it('still activates when Redis indexUser fails', async () => {
+			const user = { ...mockUser(), isActive: false } as User;
+			userRepository.findById.mockResolvedValue(user);
+			userRepository.updateStatus.mockResolvedValue(undefined);
+			searchIndexService.indexUser.mockRejectedValueOnce(new Error('Redis down'));
+
+			await expect(service.activate('uuid-1')).resolves.toBeUndefined();
+			expect(userRepository.updateStatus).toHaveBeenCalledWith('uuid-1', true);
+		});
+
 		it('throws NotFoundException when user does not exist', async () => {
 			userRepository.findById.mockResolvedValue(null);
 
@@ -255,6 +274,15 @@ describe('AccountsService', () => {
 			await service.remove('uuid-1');
 
 			expect(searchIndexService.removeUserFromIndex).toHaveBeenCalledWith(user);
+		});
+
+		it('still removes when Redis removeUserFromIndex fails', async () => {
+			userRepository.findById.mockResolvedValue(mockUser());
+			userRepository.softDelete.mockResolvedValue(undefined);
+			searchIndexService.removeUserFromIndex.mockRejectedValueOnce(new Error('Redis down'));
+
+			await expect(service.remove('uuid-1')).resolves.toBeUndefined();
+			expect(userRepository.softDelete).toHaveBeenCalledWith('uuid-1');
 		});
 
 		it('throws NotFoundException when user does not exist', async () => {

--- a/src/modules/accounts/services/accounts.service.spec.ts
+++ b/src/modules/accounts/services/accounts.service.spec.ts
@@ -22,7 +22,7 @@ describe('AccountsService', () => {
 	let service: AccountsService;
 	let userRepository: jest.Mocked<UserRepository>;
 	let eventsClient: { emit: jest.Mock };
-	let searchIndexService: { indexUser: jest.Mock };
+	let searchIndexService: { indexUser: jest.Mock; removeUserFromIndex: jest.Mock };
 
 	beforeEach(async () => {
 		eventsClient = { emit: jest.fn().mockReturnValue(of(undefined)) };
@@ -49,6 +49,7 @@ describe('AccountsService', () => {
 					provide: SearchIndexService,
 					useValue: {
 						indexUser: jest.fn().mockResolvedValue(undefined),
+						removeUserFromIndex: jest.fn().mockResolvedValue(undefined),
 					},
 				},
 			],

--- a/src/modules/accounts/services/accounts.service.spec.ts
+++ b/src/modules/accounts/services/accounts.service.spec.ts
@@ -218,14 +218,16 @@ describe('AccountsService', () => {
 			expect(userRepository.updateStatus).toHaveBeenCalledWith('uuid-1', true);
 		});
 
-		it('re-indexes user in search on activation', async () => {
-			const user = mockUser();
+		it('re-indexes user with isActive true after activation', async () => {
+			const user = { ...mockUser(), isActive: false } as User;
 			userRepository.findById.mockResolvedValue(user);
 			userRepository.updateStatus.mockResolvedValue(undefined);
 
 			await service.activate('uuid-1');
 
-			expect(searchIndexService.indexUser).toHaveBeenCalledWith(user);
+			expect(searchIndexService.indexUser).toHaveBeenCalledWith(
+				expect.objectContaining({ isActive: true })
+			);
 		});
 
 		it('throws NotFoundException when user does not exist', async () => {

--- a/src/modules/accounts/services/accounts.service.ts
+++ b/src/modules/accounts/services/accounts.service.ts
@@ -113,8 +113,13 @@ export class AccountsService {
 	}
 
 	public async activate(id: string): Promise<void> {
-		await this.findOne(id);
+		const user = await this.findOne(id);
 		await this.userRepository.updateStatus(id, true);
+		try {
+			await this.searchIndexService.indexUser(user);
+		} catch (err) {
+			this.logger.warn(`Failed to re-index user ${id} in search: ${err}`);
+		}
 	}
 
 	public async remove(id: string): Promise<void> {

--- a/src/modules/accounts/services/accounts.service.ts
+++ b/src/modules/accounts/services/accounts.service.ts
@@ -115,6 +115,7 @@ export class AccountsService {
 	public async activate(id: string): Promise<void> {
 		const user = await this.findOne(id);
 		await this.userRepository.updateStatus(id, true);
+		user.isActive = true;
 		try {
 			await this.searchIndexService.indexUser(user);
 		} catch (err) {

--- a/src/modules/accounts/services/accounts.service.ts
+++ b/src/modules/accounts/services/accounts.service.ts
@@ -103,8 +103,13 @@ export class AccountsService {
 	}
 
 	public async deactivate(id: string): Promise<void> {
-		await this.findOne(id);
+		const user = await this.findOne(id);
 		await this.userRepository.updateStatus(id, false);
+		try {
+			await this.searchIndexService.removeUserFromIndex(user);
+		} catch (err) {
+			this.logger.warn(`Failed to remove user ${id} from search index: ${err}`);
+		}
 	}
 
 	public async activate(id: string): Promise<void> {
@@ -113,7 +118,12 @@ export class AccountsService {
 	}
 
 	public async remove(id: string): Promise<void> {
-		await this.findOne(id);
+		const user = await this.findOne(id);
 		await this.userRepository.softDelete(id);
+		try {
+			await this.searchIndexService.removeUserFromIndex(user);
+		} catch (err) {
+			this.logger.warn(`Failed to remove user ${id} from search index: ${err}`);
+		}
 	}
 }

--- a/src/modules/profile/services/profile.service.spec.ts
+++ b/src/modules/profile/services/profile.service.spec.ts
@@ -149,6 +149,22 @@ describe('ProfileService', () => {
 			expect(searchIndexService.indexUser).toHaveBeenCalledWith(saved);
 		});
 
+		it('removes old index entries when username changes', async () => {
+			const user = { ...mockUser(), username: 'old-name' } as User;
+			const dto: UpdateProfileDto = { username: 'new-name' };
+			const saved = { ...user, username: 'new-name' } as User;
+
+			userRepository.findById.mockResolvedValue(user);
+			userRepository.findByUsernameInsensitive.mockResolvedValue(null);
+			userRepository.save.mockResolvedValue(saved);
+
+			await service.updateProfile('uuid-1', dto);
+
+			expect(searchIndexService.removeUserFromIndex).toHaveBeenCalledWith(
+				expect.objectContaining({ username: 'old-name' })
+			);
+		});
+
 		it('swallows search indexing errors without failing the update', async () => {
 			const user = mockUser();
 			const dto: UpdateProfileDto = { firstName: 'Alice' };

--- a/src/modules/profile/services/profile.service.spec.ts
+++ b/src/modules/profile/services/profile.service.spec.ts
@@ -36,7 +36,7 @@ describe('ProfileService', () => {
 	let service: ProfileService;
 	let userRepository: jest.Mocked<UserRepository>;
 	let mediaClient: jest.Mocked<MediaClientService>;
-	let searchIndexService: { indexUser: jest.Mock };
+	let searchIndexService: { indexUser: jest.Mock; removeUserFromIndex: jest.Mock };
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
@@ -60,6 +60,7 @@ describe('ProfileService', () => {
 					provide: SearchIndexService,
 					useValue: {
 						indexUser: jest.fn().mockResolvedValue(undefined),
+						removeUserFromIndex: jest.fn().mockResolvedValue(undefined),
 					},
 				},
 			],

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -75,8 +75,10 @@ export class ProfileService {
 			saved.lastName !== previousSnapshot.lastName
 		) {
 			try {
-				await this.searchIndexService.removeUserFromIndex(previousSnapshot as User);
+				// Index new data first, then remove old entries — if indexUser fails,
+				// the user remains discoverable under the old keys instead of vanishing.
 				await this.searchIndexService.indexUser(saved);
+				await this.searchIndexService.removeUserFromIndex(previousSnapshot);
 			} catch (err) {
 				this.logger.warn(`Failed to update search index for user ${saved.id}: ${err}`);
 			}

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -37,11 +37,7 @@ export class ProfileService {
 
 	public async updateProfile(id: string, dto: UpdateProfileDto, authorization?: string): Promise<User> {
 		const user = await this.findOne(id);
-		const previous = {
-			username: user.username,
-			firstName: user.firstName,
-			lastName: user.lastName,
-		};
+		const previousSnapshot = { ...user };
 
 		if (dto.username && dto.username !== user.username) {
 			const existing = await this.userRepository.findByUsernameInsensitive(dto.username, true);
@@ -74,14 +70,15 @@ export class ProfileService {
 		const saved = await this.userRepository.save(user);
 
 		if (
-			saved.username !== previous.username ||
-			saved.firstName !== previous.firstName ||
-			saved.lastName !== previous.lastName
+			saved.username !== previousSnapshot.username ||
+			saved.firstName !== previousSnapshot.firstName ||
+			saved.lastName !== previousSnapshot.lastName
 		) {
 			try {
+				await this.searchIndexService.removeUserFromIndex(previousSnapshot as User);
 				await this.searchIndexService.indexUser(saved);
 			} catch (err) {
-				this.logger.warn(`Failed to index user ${saved.id} in search: ${err}`);
+				this.logger.warn(`Failed to update search index for user ${saved.id}: ${err}`);
 			}
 		}
 


### PR DESCRIPTION
## Summary\n- Call `removeUserFromIndex(previousSnapshot)` in `ProfileService.updateProfile` before re-indexing when username/name changes\n- Call `removeUserFromIndex` in `AccountsService.deactivate` and `AccountsService.remove`\n- Prevents deactivated/deleted users and stale usernames from remaining searchable in Redis\n\n## Test plan\n- [x] Unit tests green (437/437)\n- [x] E2E tests green (2/2)\n- [x] Lint clean\n\nCloses WHISPR-825