### PR TITLE
[WHISPR-827] refactor(cache): remove unused CacheService methods

### DIFF
--- a/src/modules/cache/cache.service.spec.ts
+++ b/src/modules/cache/cache.service.spec.ts
@@ -2,24 +2,12 @@ import { CacheService } from './cache.service';
 import { RedisConfig } from '../../config/redis.config';
 
 const mockRedis = {
-	set: jest.fn(),
-	setex: jest.fn(),
 	get: jest.fn(),
+	hget: jest.fn(),
 	del: jest.fn(),
-	exists: jest.fn(),
-	expire: jest.fn(),
 	keys: jest.fn(),
-	sadd: jest.fn(),
-	srem: jest.fn(),
-	smembers: jest.fn(),
-	sismember: jest.fn(),
-	zadd: jest.fn(),
 	zrange: jest.fn(),
-	zrem: jest.fn(),
-	incr: jest.fn(),
-	decr: jest.fn(),
 	pipeline: jest.fn(),
-	flushall: jest.fn(),
 };
 
 const mockRedisConfig = {
@@ -32,30 +20,6 @@ describe('CacheService', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		service = new CacheService(mockRedisConfig);
-	});
-
-	describe('set', () => {
-		it('should call setex when ttl is provided', async () => {
-			mockRedis.setex.mockResolvedValue('OK');
-			await service.set('key', { foo: 'bar' }, 60);
-			expect(mockRedis.setex).toHaveBeenCalledWith('key', 60, JSON.stringify({ foo: 'bar' }));
-		});
-
-		it('should call set when no ttl is provided', async () => {
-			mockRedis.set.mockResolvedValue('OK');
-			await service.set('key', 'value');
-			expect(mockRedis.set).toHaveBeenCalledWith('key', JSON.stringify('value'));
-		});
-
-		it('should throw when redis.set fails', async () => {
-			mockRedis.set.mockRejectedValue(new Error('Redis error'));
-			await expect(service.set('key', 'value')).rejects.toThrow('Redis error');
-		});
-
-		it('should throw when redis.setex fails', async () => {
-			mockRedis.setex.mockRejectedValue(new Error('Redis error'));
-			await expect(service.set('key', 'value', 30)).rejects.toThrow('Redis error');
-		});
 	});
 
 	describe('get', () => {
@@ -78,19 +42,6 @@ describe('CacheService', () => {
 		});
 	});
 
-	describe('del', () => {
-		it('should delete a key', async () => {
-			mockRedis.del.mockResolvedValue(1);
-			await expect(service.del('key')).resolves.toBeUndefined();
-			expect(mockRedis.del).toHaveBeenCalledWith('key');
-		});
-
-		it('should throw when redis fails', async () => {
-			mockRedis.del.mockRejectedValue(new Error('Redis error'));
-			await expect(service.del('key')).rejects.toThrow('Redis error');
-		});
-	});
-
 	describe('delMany', () => {
 		it('should delete multiple keys', async () => {
 			mockRedis.del.mockResolvedValue(2);
@@ -109,36 +60,6 @@ describe('CacheService', () => {
 		});
 	});
 
-	describe('exists', () => {
-		it('should return true when key exists', async () => {
-			mockRedis.exists.mockResolvedValue(1);
-			expect(await service.exists('key')).toBe(true);
-		});
-
-		it('should return false when key does not exist', async () => {
-			mockRedis.exists.mockResolvedValue(0);
-			expect(await service.exists('key')).toBe(false);
-		});
-
-		it('should return false when redis fails', async () => {
-			mockRedis.exists.mockRejectedValue(new Error('Redis error'));
-			expect(await service.exists('key')).toBe(false);
-		});
-	});
-
-	describe('expire', () => {
-		it('should set TTL on a key', async () => {
-			mockRedis.expire.mockResolvedValue(1);
-			await expect(service.expire('key', 120)).resolves.toBeUndefined();
-			expect(mockRedis.expire).toHaveBeenCalledWith('key', 120);
-		});
-
-		it('should throw when redis fails', async () => {
-			mockRedis.expire.mockRejectedValue(new Error('Redis error'));
-			await expect(service.expire('key', 120)).rejects.toThrow('Redis error');
-		});
-	});
-
 	describe('keys', () => {
 		it('should return matching keys', async () => {
 			mockRedis.keys.mockResolvedValue(['user:1', 'user:2']);
@@ -153,76 +74,18 @@ describe('CacheService', () => {
 		});
 	});
 
-	describe('sadd', () => {
-		it('should add members to a set and return count', async () => {
-			mockRedis.sadd.mockResolvedValue(2);
-			const result = await service.sadd('myset', 'a', 'b');
-			expect(result).toBe(2);
-			expect(mockRedis.sadd).toHaveBeenCalledWith('myset', 'a', 'b');
+	describe('hget', () => {
+		it('should return field value from hash', async () => {
+			mockRedis.hget.mockResolvedValue('user-1');
+			const result = await service.hget('search:phone', '+33600000001');
+			expect(result).toBe('user-1');
+			expect(mockRedis.hget).toHaveBeenCalledWith('search:phone', '+33600000001');
 		});
 
-		it('should throw when redis fails', async () => {
-			mockRedis.sadd.mockRejectedValue(new Error('Redis error'));
-			await expect(service.sadd('myset', 'a')).rejects.toThrow('Redis error');
-		});
-	});
-
-	describe('srem', () => {
-		it('should remove members from a set and return count', async () => {
-			mockRedis.srem.mockResolvedValue(1);
-			const result = await service.srem('myset', 'a');
-			expect(result).toBe(1);
-			expect(mockRedis.srem).toHaveBeenCalledWith('myset', 'a');
-		});
-
-		it('should throw when redis fails', async () => {
-			mockRedis.srem.mockRejectedValue(new Error('Redis error'));
-			await expect(service.srem('myset', 'a')).rejects.toThrow('Redis error');
-		});
-	});
-
-	describe('smembers', () => {
-		it('should return set members', async () => {
-			mockRedis.smembers.mockResolvedValue(['a', 'b', 'c']);
-			const result = await service.smembers('myset');
-			expect(result).toEqual(['a', 'b', 'c']);
-		});
-
-		it('should return empty array when redis fails', async () => {
-			mockRedis.smembers.mockRejectedValue(new Error('Redis error'));
-			const result = await service.smembers('myset');
-			expect(result).toEqual([]);
-		});
-	});
-
-	describe('sismember', () => {
-		it('should return true when member is in set', async () => {
-			mockRedis.sismember.mockResolvedValue(1);
-			expect(await service.sismember('myset', 'a')).toBe(true);
-		});
-
-		it('should return false when member is not in set', async () => {
-			mockRedis.sismember.mockResolvedValue(0);
-			expect(await service.sismember('myset', 'a')).toBe(false);
-		});
-
-		it('should return false when redis fails', async () => {
-			mockRedis.sismember.mockRejectedValue(new Error('Redis error'));
-			expect(await service.sismember('myset', 'a')).toBe(false);
-		});
-	});
-
-	describe('zadd', () => {
-		it('should add member to sorted set and return count', async () => {
-			mockRedis.zadd.mockResolvedValue(1);
-			const result = await service.zadd('zset', 1.0, 'member');
-			expect(result).toBe(1);
-			expect(mockRedis.zadd).toHaveBeenCalledWith('zset', 1.0, 'member');
-		});
-
-		it('should throw when redis fails', async () => {
-			mockRedis.zadd.mockRejectedValue(new Error('Redis error'));
-			await expect(service.zadd('zset', 1.0, 'member')).rejects.toThrow('Redis error');
+		it('should return null when redis fails', async () => {
+			mockRedis.hget.mockRejectedValue(new Error('Redis error'));
+			const result = await service.hget('search:phone', '+33600000001');
+			expect(result).toBeNull();
 		});
 	});
 
@@ -238,48 +101,6 @@ describe('CacheService', () => {
 			mockRedis.zrange.mockRejectedValue(new Error('Redis error'));
 			const result = await service.zrange('zset', 0, -1);
 			expect(result).toEqual([]);
-		});
-	});
-
-	describe('zrem', () => {
-		it('should remove members from sorted set and return count', async () => {
-			mockRedis.zrem.mockResolvedValue(1);
-			const result = await service.zrem('zset', 'a', 'b');
-			expect(result).toBe(1);
-			expect(mockRedis.zrem).toHaveBeenCalledWith('zset', 'a', 'b');
-		});
-
-		it('should throw when redis fails', async () => {
-			mockRedis.zrem.mockRejectedValue(new Error('Redis error'));
-			await expect(service.zrem('zset', 'a')).rejects.toThrow('Redis error');
-		});
-	});
-
-	describe('incr', () => {
-		it('should increment counter and return new value', async () => {
-			mockRedis.incr.mockResolvedValue(5);
-			const result = await service.incr('counter');
-			expect(result).toBe(5);
-			expect(mockRedis.incr).toHaveBeenCalledWith('counter');
-		});
-
-		it('should throw when redis fails', async () => {
-			mockRedis.incr.mockRejectedValue(new Error('Redis error'));
-			await expect(service.incr('counter')).rejects.toThrow('Redis error');
-		});
-	});
-
-	describe('decr', () => {
-		it('should decrement counter and return new value', async () => {
-			mockRedis.decr.mockResolvedValue(3);
-			const result = await service.decr('counter');
-			expect(result).toBe(3);
-			expect(mockRedis.decr).toHaveBeenCalledWith('counter');
-		});
-
-		it('should throw when redis fails', async () => {
-			mockRedis.decr.mockRejectedValue(new Error('Redis error'));
-			await expect(service.decr('counter')).rejects.toThrow('Redis error');
 		});
 	});
 
@@ -328,19 +149,6 @@ describe('CacheService', () => {
 			});
 
 			await expect(service.pipeline([['set', 'key', 'val']])).rejects.toThrow('Pipeline error');
-		});
-	});
-
-	describe('flushall', () => {
-		it('should flush all keys', async () => {
-			mockRedis.flushall.mockResolvedValue('OK');
-			await expect(service.flushall()).resolves.toBeUndefined();
-			expect(mockRedis.flushall).toHaveBeenCalled();
-		});
-
-		it('should throw when redis fails', async () => {
-			mockRedis.flushall.mockRejectedValue(new Error('Redis error'));
-			await expect(service.flushall()).rejects.toThrow('Redis error');
 		});
 	});
 });

--- a/src/modules/cache/cache.service.ts
+++ b/src/modules/cache/cache.service.ts
@@ -11,20 +11,6 @@ export class CacheService {
 		this.redis = this.redisConfig.getClient();
 	}
 
-	async set(key: string, value: any, ttl?: number): Promise<void> {
-		try {
-			const serializedValue = JSON.stringify(value);
-			if (ttl) {
-				await this.redis.setex(key, ttl, serializedValue);
-			} else {
-				await this.redis.set(key, serializedValue);
-			}
-		} catch (error) {
-			this.logger.error(`Failed to set cache key ${key}:`, error);
-			throw error;
-		}
-	}
-
 	async get<T>(key: string): Promise<T | null> {
 		try {
 			const value = await this.redis.get(key);
@@ -44,40 +30,12 @@ export class CacheService {
 		}
 	}
 
-	async del(key: string): Promise<void> {
-		try {
-			await this.redis.del(key);
-		} catch (error) {
-			this.logger.error(`Failed to delete cache key ${key}:`, error);
-			throw error;
-		}
-	}
-
 	async delMany(keys: string[]): Promise<void> {
 		if (keys.length === 0) return;
 		try {
 			await this.redis.del(...keys);
 		} catch (error) {
 			this.logger.error(`Failed to delete cache keys:`, error);
-			throw error;
-		}
-	}
-
-	async exists(key: string): Promise<boolean> {
-		try {
-			const result = await this.redis.exists(key);
-			return result === 1;
-		} catch (error) {
-			this.logger.error(`Failed to check existence of cache key ${key}:`, error);
-			return false;
-		}
-	}
-
-	async expire(key: string, ttl: number): Promise<void> {
-		try {
-			await this.redis.expire(key, ttl);
-		} catch (error) {
-			this.logger.error(`Failed to set TTL for cache key ${key}:`, error);
 			throw error;
 		}
 	}
@@ -91,85 +49,12 @@ export class CacheService {
 		}
 	}
 
-	async sadd(key: string, ...members: string[]): Promise<number> {
-		try {
-			return await this.redis.sadd(key, ...members);
-		} catch (error) {
-			this.logger.error(`Failed to add to set ${key}:`, error);
-			throw error;
-		}
-	}
-
-	async srem(key: string, ...members: string[]): Promise<number> {
-		try {
-			return await this.redis.srem(key, ...members);
-		} catch (error) {
-			this.logger.error(`Failed to remove from set ${key}:`, error);
-			throw error;
-		}
-	}
-
-	async smembers(key: string): Promise<string[]> {
-		try {
-			return await this.redis.smembers(key);
-		} catch (error) {
-			this.logger.error(`Failed to get members of set ${key}:`, error);
-			return [];
-		}
-	}
-
-	async sismember(key: string, member: string): Promise<boolean> {
-		try {
-			const result = await this.redis.sismember(key, member);
-			return result === 1;
-		} catch (error) {
-			this.logger.error(`Failed to check membership in set ${key}:`, error);
-			return false;
-		}
-	}
-
-	async zadd(key: string, score: number, member: string): Promise<number> {
-		try {
-			return await this.redis.zadd(key, score, member);
-		} catch (error) {
-			this.logger.error(`Failed to add to sorted set ${key}:`, error);
-			throw error;
-		}
-	}
-
 	async zrange(key: string, start: number, stop: number): Promise<string[]> {
 		try {
 			return await this.redis.zrange(key, start, stop);
 		} catch (error) {
 			this.logger.error(`Failed to get range from sorted set ${key}:`, error);
 			return [];
-		}
-	}
-
-	async zrem(key: string, ...members: string[]): Promise<number> {
-		try {
-			return await this.redis.zrem(key, ...members);
-		} catch (error) {
-			this.logger.error(`Failed to remove from sorted set ${key}:`, error);
-			throw error;
-		}
-	}
-
-	async incr(key: string): Promise<number> {
-		try {
-			return await this.redis.incr(key);
-		} catch (error) {
-			this.logger.error(`Failed to increment counter ${key}:`, error);
-			throw error;
-		}
-	}
-
-	async decr(key: string): Promise<number> {
-		try {
-			return await this.redis.decr(key);
-		} catch (error) {
-			this.logger.error(`Failed to decrement counter ${key}:`, error);
-			throw error;
 		}
 	}
 
@@ -188,15 +73,6 @@ export class CacheService {
 			);
 		} catch (error) {
 			this.logger.error('Failed to execute pipeline:', error);
-			throw error;
-		}
-	}
-
-	async flushall(): Promise<void> {
-		try {
-			await this.redis.flushall();
-		} catch (error) {
-			this.logger.error('Failed to flush all cache:', error);
 			throw error;
 		}
 	}


### PR DESCRIPTION
## Summary\n- Remove 13 unused methods from CacheService: `set`, `del`, `exists`, `expire`, `sadd`, `srem`, `smembers`, `sismember`, `zadd`, `zrem`, `incr`, `decr`, `flushall`\n- Keep only `get`, `hget`, `delMany`, `keys`, `zrange`, `pipeline` (used by SearchIndexService)\n- Remove corresponding tests (-28 tests, -327 lines)\n- Add missing `hget` test\n\n## Test plan\n- [x] Unit tests green (409/409)\n- [x] E2E tests green (2/2)\n- [x] Lint clean\n\nCloses WHISPR-827