### PR TITLE
[WHISPR-820] feat(security): add global rate-limiting with @nestjs/throttler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@nestjs/platform-express": "^11.1.18",
 				"@nestjs/swagger": "^11.2.5",
 				"@nestjs/terminus": "^11.1.1",
+				"@nestjs/throttler": "^6.5.0",
 				"@nestjs/typeorm": "^11.0.0",
 				"bcrypt": "^6.0.0",
 				"class-transformer": "^0.5.1",
@@ -3326,6 +3327,17 @@
 				}
 			}
 		},
+		"node_modules/@nestjs/throttler": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+			"integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+				"@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+				"reflect-metadata": "^0.1.13 || ^0.2.0"
+			}
+		},
 		"node_modules/@nestjs/typeorm": {
 			"version": "11.0.0",
 			"resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.0.tgz",
@@ -3592,7 +3604,7 @@
 			"version": "1.15.8",
 			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.8.tgz",
 			"integrity": "sha512-T8keoJjXaSUoVBCIjgL6wAnhADIb09GOELzKg10CjNg+vLX48P93SME6jTfte9MZIm5m+Il57H3rTSk/0kzDUw==",
-			"devOptional": true,
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3634,6 +3646,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -3650,6 +3663,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -3666,6 +3680,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3682,6 +3697,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -3698,6 +3714,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -3714,6 +3731,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -3730,6 +3748,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -3746,6 +3765,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -3762,6 +3782,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -3778,6 +3799,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -3791,14 +3813,14 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
 			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@swc/types": {
 			"version": "0.1.25",
 			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
 			"integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"@nestjs/platform-express": "^11.1.18",
 		"@nestjs/swagger": "^11.2.5",
 		"@nestjs/terminus": "^11.1.1",
+		"@nestjs/throttler": "^6.5.0",
 		"@nestjs/typeorm": "^11.0.0",
 		"bcrypt": "^6.0.0",
 		"class-transformer": "^0.5.1",

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -2,7 +2,8 @@ import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { HttpThrottlerGuard } from './http-throttler.guard';
 import { typeOrmModuleAsyncOptions } from '../typeorm.config';
 import { CacheModule } from './cache';
 import { HealthModule } from './health/health.module';
@@ -41,11 +42,11 @@ const GLOBAL_THROTTLE_LIMIT = 60;
 	providers: [
 		{
 			provide: APP_GUARD,
-			useClass: JwtAuthGuard,
+			useClass: HttpThrottlerGuard,
 		},
 		{
 			provide: APP_GUARD,
-			useClass: ThrottlerGuard,
+			useClass: JwtAuthGuard,
 		},
 	],
 })

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -16,6 +16,9 @@ import { UserSearchModule } from './search/user-search.module';
 import { JwtAuthModule } from './jwt-auth/jwt-auth.module';
 import { JwtAuthGuard } from './jwt-auth/jwt-auth.guard';
 
+const GLOBAL_THROTTLE_TTL_MS = 60_000;
+const GLOBAL_THROTTLE_LIMIT = 60;
+
 @Module({
 	imports: [
 		ConfigModule.forRoot({
@@ -23,7 +26,7 @@ import { JwtAuthGuard } from './jwt-auth/jwt-auth.guard';
 			envFilePath: ['.env.development', '.env.local', '.env'],
 		}),
 		TypeOrmModule.forRootAsync(typeOrmModuleAsyncOptions),
-		ThrottlerModule.forRoot([{ ttl: 60000, limit: 60 }]),
+		ThrottlerModule.forRoot([{ ttl: GLOBAL_THROTTLE_TTL_MS, limit: GLOBAL_THROTTLE_LIMIT }]),
 		CacheModule,
 		JwtAuthModule,
 		HealthModule,

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { typeOrmModuleAsyncOptions } from '../typeorm.config';
 import { CacheModule } from './cache';
 import { HealthModule } from './health/health.module';
@@ -22,6 +23,7 @@ import { JwtAuthGuard } from './jwt-auth/jwt-auth.guard';
 			envFilePath: ['.env.development', '.env.local', '.env'],
 		}),
 		TypeOrmModule.forRootAsync(typeOrmModuleAsyncOptions),
+		ThrottlerModule.forRoot([{ ttl: 60000, limit: 60 }]),
 		CacheModule,
 		JwtAuthModule,
 		HealthModule,
@@ -37,6 +39,10 @@ import { JwtAuthGuard } from './jwt-auth/jwt-auth.guard';
 		{
 			provide: APP_GUARD,
 			useClass: JwtAuthGuard,
+		},
+		{
+			provide: APP_GUARD,
+			useClass: ThrottlerGuard,
 		},
 	],
 })

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
+import { SkipThrottle } from '@nestjs/throttler';
 import { Public } from '../jwt-auth/public.decorator';
 import { JwksHealthIndicator } from '../jwt-auth/jwks-health.indicator';
 import { RedisHealthIndicator } from './redis-health.indicator';
@@ -8,6 +9,7 @@ import { RedisHealthIndicator } from './redis-health.indicator';
 const DB_TIMEOUT_MS = 3_000;
 
 @Public()
+@SkipThrottle()
 @ApiTags('Health')
 @Controller('health')
 export class HealthController {

--- a/src/modules/http-throttler.guard.spec.ts
+++ b/src/modules/http-throttler.guard.spec.ts
@@ -1,0 +1,33 @@
+import { ExecutionContext } from '@nestjs/common';
+import { HttpThrottlerGuard } from './http-throttler.guard';
+
+describe('HttpThrottlerGuard', () => {
+	let guard: HttpThrottlerGuard;
+
+	beforeEach(() => {
+		guard = Object.create(HttpThrottlerGuard.prototype);
+	});
+
+	describe('shouldSkip', () => {
+		it('should skip non-http contexts', async () => {
+			const context = { getType: () => 'rpc' } as unknown as ExecutionContext;
+
+			const result = await guard['shouldSkip'](context);
+
+			expect(result).toBe(true);
+		});
+
+		it('should not skip http contexts', async () => {
+			const context = { getType: () => 'http' } as unknown as ExecutionContext;
+
+			// Mock the parent shouldSkip to return false (default behavior)
+			jest.spyOn(Object.getPrototypeOf(HttpThrottlerGuard.prototype), 'shouldSkip').mockResolvedValue(
+				false
+			);
+
+			const result = await guard['shouldSkip'](context);
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/src/modules/http-throttler.guard.ts
+++ b/src/modules/http-throttler.guard.ts
@@ -1,0 +1,13 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+@Injectable()
+export class HttpThrottlerGuard extends ThrottlerGuard {
+	protected async shouldSkip(context: ExecutionContext): Promise<boolean> {
+		if (context.getType() !== 'http') {
+			return true;
+		}
+
+		return super.shouldSkip(context);
+	}
+}

--- a/src/modules/search/controllers/user-search.controller.ts
+++ b/src/modules/search/controllers/user-search.controller.ts
@@ -5,9 +5,12 @@ import { UserSearchService, UserSearchResult } from '../services/user-search.ser
 import { User } from '../../common/entities/user.entity';
 import { BatchPhoneSearchDto } from '../dto/batch-phone-search.dto';
 
+const SEARCH_THROTTLE_TTL_MS = 60_000;
+const SEARCH_THROTTLE_LIMIT = 20;
+
 @ApiTags('Search')
 @ApiBearerAuth()
-@Throttle({ default: { ttl: 60000, limit: 20 } })
+@Throttle({ default: { ttl: SEARCH_THROTTLE_TTL_MS, limit: SEARCH_THROTTLE_LIMIT } })
 @Controller('search')
 export class UserSearchController {
 	constructor(private readonly userSearchService: UserSearchService) {}

--- a/src/modules/search/controllers/user-search.controller.ts
+++ b/src/modules/search/controllers/user-search.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Get, Post, Query, Body, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiQuery, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { UserSearchService, UserSearchResult } from '../services/user-search.service';
 import { User } from '../../common/entities/user.entity';
 import { BatchPhoneSearchDto } from '../dto/batch-phone-search.dto';
 
 @ApiTags('Search')
 @ApiBearerAuth()
+@Throttle({ default: { ttl: 60000, limit: 20 } })
 @Controller('search')
 export class UserSearchController {
 	constructor(private readonly userSearchService: UserSearchService) {}


### PR DESCRIPTION
## Summary\n- Install `@nestjs/throttler` and configure `ThrottlerModule` with global 60 req/min per IP\n- Apply stricter 20 req/min limit on `/search` endpoints via `@Throttle()` decorator\n- Skip throttle on health check endpoints via `@SkipThrottle()` to avoid monitoring false alerts\n- Register `ThrottlerGuard` as a global guard\n\n## Test plan\n- [x] Unit tests green (437/437)\n- [x] E2E tests green (2/2)\n- [x] Lint clean\n\nCloses WHISPR-820