### PR TITLE
[WHISPR-829] fix(search): add query DTOs with validation, cap limit and escape wildcards

### DIFF
--- a/src/modules/common/repositories/user.repository.spec.ts
+++ b/src/modules/common/repositories/user.repository.spec.ts
@@ -302,6 +302,21 @@ describe('UserRepository', () => {
 			});
 			expect(result).toHaveLength(2);
 		});
+
+		it('escapes SQL wildcard characters in the query', async () => {
+			mockTypeormRepo.find.mockResolvedValue([]);
+
+			await repo.searchByDisplayName('%_test');
+
+			expect(mockTypeormRepo.find).toHaveBeenCalledWith({
+				where: [
+					{ firstName: ILike('%\\%\\_test%'), isActive: true },
+					{ lastName: ILike('%\\%\\_test%'), isActive: true },
+				],
+				take: 40,
+				order: { createdAt: 'DESC' },
+			});
+		});
 	});
 
 	describe('updateLastSeen', () => {

--- a/src/modules/common/repositories/user.repository.ts
+++ b/src/modules/common/repositories/user.repository.ts
@@ -127,7 +127,8 @@ export class UserRepository {
 	 * Search users by first name or last name
 	 */
 	async searchByDisplayName(query: string, limit: number = 20): Promise<User[]> {
-		const pattern = `%${query}%`;
+		const escaped = query.replace(/[%_\\]/g, (c) => '\\' + c);
+		const pattern = `%${escaped}%`;
 		const rows = await this.repository.find({
 			where: [
 				{ firstName: ILike(pattern), isActive: true },

--- a/src/modules/search/controllers/user-search.controller.spec.ts
+++ b/src/modules/search/controllers/user-search.controller.spec.ts
@@ -33,7 +33,7 @@ describe('UserSearchController', () => {
 			const user = { id: 'u1' } as User;
 			service.searchByPhone.mockResolvedValue(user);
 
-			const result = await controller.searchByPhone('+33600000000');
+			const result = await controller.searchByPhone({ phoneNumber: '+33600000000' });
 
 			expect(result).toBe(user);
 			expect(service.searchByPhone).toHaveBeenCalledWith('+33600000000');
@@ -72,7 +72,7 @@ describe('UserSearchController', () => {
 			];
 			service.searchByDisplayName.mockResolvedValue(results);
 
-			const result = await controller.searchByName('alice', 5);
+			const result = await controller.searchByName({ query: 'alice', limit: 5 });
 
 			expect(result).toBe(results);
 			expect(service.searchByDisplayName).toHaveBeenCalledWith('alice', 5);
@@ -81,7 +81,7 @@ describe('UserSearchController', () => {
 		it('omits the limit when not provided', async () => {
 			service.searchByDisplayName.mockResolvedValue([]);
 
-			await controller.searchByName('alice');
+			await controller.searchByName({ query: 'alice' });
 
 			expect(service.searchByDisplayName).toHaveBeenCalledWith('alice', undefined);
 		});

--- a/src/modules/search/controllers/user-search.controller.ts
+++ b/src/modules/search/controllers/user-search.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Get, Post, Query, Body, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiQuery, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { UserSearchService, UserSearchResult } from '../services/user-search.service';
 import { User } from '../../common/entities/user.entity';
 import { BatchPhoneSearchDto } from '../dto/batch-phone-search.dto';
+import { PhoneSearchQueryDto } from '../dto/phone-search-query.dto';
+import { NameSearchQueryDto } from '../dto/name-search-query.dto';
 
 @ApiTags('Search')
 @ApiBearerAuth()
@@ -12,11 +14,10 @@ export class UserSearchController {
 
 	@Get('phone')
 	@ApiOperation({ summary: 'Search user by phone number' })
-	@ApiQuery({ name: 'phoneNumber', type: 'string', description: 'E.164 phone number' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'User found or null' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async searchByPhone(@Query('phoneNumber') phoneNumber: string): Promise<User | null> {
-		return this.userSearchService.searchByPhone(phoneNumber);
+	async searchByPhone(@Query() dto: PhoneSearchQueryDto): Promise<User | null> {
+		return this.userSearchService.searchByPhone(dto.phoneNumber);
 	}
 
 	@Post('phone/batch')
@@ -29,7 +30,6 @@ export class UserSearchController {
 
 	@Get('username')
 	@ApiOperation({ summary: 'Search user by username' })
-	@ApiQuery({ name: 'username', type: 'string', description: 'Username' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'User found or null' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async searchByUsername(@Query('username') username: string): Promise<User | null> {
@@ -38,14 +38,9 @@ export class UserSearchController {
 
 	@Get('name')
 	@ApiOperation({ summary: 'Search users by display name' })
-	@ApiQuery({ name: 'query', type: 'string', description: 'Name search query' })
-	@ApiQuery({ name: 'limit', type: 'number', required: false, description: 'Max results (default 20)' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'List of matching users' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async searchByName(
-		@Query('query') query: string,
-		@Query('limit') limit?: number
-	): Promise<UserSearchResult[]> {
-		return this.userSearchService.searchByDisplayName(query, limit);
+	async searchByName(@Query() dto: NameSearchQueryDto): Promise<UserSearchResult[]> {
+		return this.userSearchService.searchByDisplayName(dto.query, dto.limit);
 	}
 }

--- a/src/modules/search/controllers/user-search.controller.ts
+++ b/src/modules/search/controllers/user-search.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Post, Query, Body, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiQuery, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { UserSearchService, UserSearchResult } from '../services/user-search.service';
 import { User } from '../../common/entities/user.entity';
 import { BatchPhoneSearchDto } from '../dto/batch-phone-search.dto';
@@ -14,6 +14,7 @@ export class UserSearchController {
 
 	@Get('phone')
 	@ApiOperation({ summary: 'Search user by phone number' })
+	@ApiQuery({ name: 'phoneNumber', type: 'string', description: 'E.164 phone number' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'User found or null' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async searchByPhone(@Query() dto: PhoneSearchQueryDto): Promise<User | null> {
@@ -30,6 +31,7 @@ export class UserSearchController {
 
 	@Get('username')
 	@ApiOperation({ summary: 'Search user by username' })
+	@ApiQuery({ name: 'username', type: 'string', description: 'Username' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'User found or null' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async searchByUsername(@Query('username') username: string): Promise<User | null> {
@@ -38,6 +40,8 @@ export class UserSearchController {
 
 	@Get('name')
 	@ApiOperation({ summary: 'Search users by display name' })
+	@ApiQuery({ name: 'query', type: 'string', description: 'Name search query' })
+	@ApiQuery({ name: 'limit', type: 'number', required: false, description: 'Max results (default 20)' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'List of matching users' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async searchByName(@Query() dto: NameSearchQueryDto): Promise<UserSearchResult[]> {

--- a/src/modules/search/controllers/user-search.controller.ts
+++ b/src/modules/search/controllers/user-search.controller.ts
@@ -41,7 +41,12 @@ export class UserSearchController {
 	@Get('name')
 	@ApiOperation({ summary: 'Search users by display name' })
 	@ApiQuery({ name: 'query', type: 'string', description: 'Name search query' })
-	@ApiQuery({ name: 'limit', type: 'number', required: false, description: 'Max results (default 20)' })
+	@ApiQuery({
+		name: 'limit',
+		required: false,
+		description: 'Max results (default 20, maximum 100)',
+		schema: { type: 'number', default: 20, maximum: 100 },
+	})
 	@ApiResponse({ status: HttpStatus.OK, description: 'List of matching users' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async searchByName(@Query() dto: NameSearchQueryDto): Promise<UserSearchResult[]> {

--- a/src/modules/search/dto/name-search-query.dto.ts
+++ b/src/modules/search/dto/name-search-query.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, IsNotEmpty, IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NameSearchQueryDto {
+	@ApiProperty({ description: 'Name search query' })
+	@IsString()
+	@IsNotEmpty()
+	query: string;
+
+	@ApiProperty({ description: 'Max results (default 20, max 100)', required: false })
+	@IsOptional()
+	@Type(() => Number)
+	@IsInt()
+	@Min(1)
+	@Max(100)
+	limit?: number;
+}

--- a/src/modules/search/dto/name-search-query.dto.ts
+++ b/src/modules/search/dto/name-search-query.dto.ts
@@ -1,6 +1,6 @@
 import { IsString, IsNotEmpty, IsOptional, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class NameSearchQueryDto {
 	@ApiProperty({ description: 'Name search query' })
@@ -8,7 +8,7 @@ export class NameSearchQueryDto {
 	@IsNotEmpty()
 	query: string;
 
-	@ApiProperty({ description: 'Max results (default 20, max 100)', required: false })
+	@ApiPropertyOptional({ description: 'Max results (default 20, max 100)' })
 	@IsOptional()
 	@Type(() => Number)
 	@IsInt()

--- a/src/modules/search/dto/phone-search-query.dto.ts
+++ b/src/modules/search/dto/phone-search-query.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PhoneSearchQueryDto {
+	@ApiProperty({ description: 'E.164 phone number', example: '+33612345678' })
+	@IsString()
+	@IsNotEmpty()
+	phoneNumber: string;
+}


### PR DESCRIPTION
## Summary\n- Introduce `PhoneSearchQueryDto` with `@IsString()` + `@IsNotEmpty()` validation\n- Introduce `NameSearchQueryDto` with `@Max(100)` limit cap and `@IsNotEmpty()` query validation\n- Escape SQL wildcards (`%`, `_`, `\\`) in `searchByDisplayName` to prevent wildcard injection\n- Update controller to use DTO objects instead of raw `@Query()` params\n\n## Test plan\n- [x] Unit tests green (437/437)\n- [x] E2E tests green (2/2)\n- [x] Lint clean\n\nCloses WHISPR-829