### PR TITLE
[WHISPR-830] perf(database): add missing secondary indexes on blocked_users, contacts and users

### DIFF
--- a/src/database/migrations/1775500200000-AddSecondaryIndexes.ts
+++ b/src/database/migrations/1775500200000-AddSecondaryIndexes.ts
@@ -6,24 +6,24 @@ export class AddSecondaryIndexes1775500200000 implements MigrationInterface {
 
 	public async up(queryRunner: QueryRunner): Promise<void> {
 		await queryRunner.query(
-			`CREATE INDEX CONCURRENTLY "IDX_blocked_users_blocked_id" ON "users"."blocked_users" ("blocked_id")`
+			`CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_blocked_users_blocked_id" ON "users"."blocked_users" ("blocked_id")`
 		);
 		await queryRunner.query(
-			`CREATE INDEX CONCURRENTLY "IDX_contacts_contact_id" ON "users"."contacts" ("contact_id")`
+			`CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_contacts_contact_id" ON "users"."contacts" ("contact_id")`
 		);
-		await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+		await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "pg_trgm" WITH SCHEMA public`);
 		await queryRunner.query(
-			`CREATE INDEX CONCURRENTLY "IDX_users_first_name_trgm" ON "users"."users" USING gin ("firstName" gin_trgm_ops)`
+			`CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_users_first_name_trgm" ON "users"."users" USING gin ("firstName" gin_trgm_ops)`
 		);
 		await queryRunner.query(
-			`CREATE INDEX CONCURRENTLY "IDX_users_last_name_trgm" ON "users"."users" USING gin ("lastName" gin_trgm_ops)`
+			`CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_users_last_name_trgm" ON "users"."users" USING gin ("lastName" gin_trgm_ops)`
 		);
 	}
 
 	public async down(queryRunner: QueryRunner): Promise<void> {
-		await queryRunner.query(`DROP INDEX CONCURRENTLY "users"."IDX_users_last_name_trgm"`);
-		await queryRunner.query(`DROP INDEX CONCURRENTLY "users"."IDX_users_first_name_trgm"`);
-		await queryRunner.query(`DROP INDEX CONCURRENTLY "users"."IDX_contacts_contact_id"`);
-		await queryRunner.query(`DROP INDEX CONCURRENTLY "users"."IDX_blocked_users_blocked_id"`);
+		await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "users"."IDX_users_last_name_trgm"`);
+		await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "users"."IDX_users_first_name_trgm"`);
+		await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "users"."IDX_contacts_contact_id"`);
+		await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "users"."IDX_blocked_users_blocked_id"`);
 	}
 }

--- a/src/database/migrations/1775500200000-AddSecondaryIndexes.ts
+++ b/src/database/migrations/1775500200000-AddSecondaryIndexes.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSecondaryIndexes1775500200000 implements MigrationInterface {
+	name = 'AddSecondaryIndexes1775500200000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE INDEX "IDX_blocked_users_blocked_id" ON "users"."blocked_users" ("blocked_id")`
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_contacts_contact_id" ON "users"."contacts" ("contact_id")`
+		);
+		await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_users_first_name_trgm" ON "users"."users" USING gin ("firstName" gin_trgm_ops)`
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_users_last_name_trgm" ON "users"."users" USING gin ("lastName" gin_trgm_ops)`
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP INDEX "users"."IDX_users_last_name_trgm"`);
+		await queryRunner.query(`DROP INDEX "users"."IDX_users_first_name_trgm"`);
+		await queryRunner.query(`DROP INDEX "users"."IDX_contacts_contact_id"`);
+		await queryRunner.query(`DROP INDEX "users"."IDX_blocked_users_blocked_id"`);
+	}
+}

--- a/src/database/migrations/1775500200000-AddSecondaryIndexes.ts
+++ b/src/database/migrations/1775500200000-AddSecondaryIndexes.ts
@@ -2,27 +2,28 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddSecondaryIndexes1775500200000 implements MigrationInterface {
 	name = 'AddSecondaryIndexes1775500200000';
+	transaction = false;
 
 	public async up(queryRunner: QueryRunner): Promise<void> {
 		await queryRunner.query(
-			`CREATE INDEX "IDX_blocked_users_blocked_id" ON "users"."blocked_users" ("blocked_id")`
+			`CREATE INDEX CONCURRENTLY "IDX_blocked_users_blocked_id" ON "users"."blocked_users" ("blocked_id")`
 		);
 		await queryRunner.query(
-			`CREATE INDEX "IDX_contacts_contact_id" ON "users"."contacts" ("contact_id")`
+			`CREATE INDEX CONCURRENTLY "IDX_contacts_contact_id" ON "users"."contacts" ("contact_id")`
 		);
 		await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
 		await queryRunner.query(
-			`CREATE INDEX "IDX_users_first_name_trgm" ON "users"."users" USING gin ("firstName" gin_trgm_ops)`
+			`CREATE INDEX CONCURRENTLY "IDX_users_first_name_trgm" ON "users"."users" USING gin ("firstName" gin_trgm_ops)`
 		);
 		await queryRunner.query(
-			`CREATE INDEX "IDX_users_last_name_trgm" ON "users"."users" USING gin ("lastName" gin_trgm_ops)`
+			`CREATE INDEX CONCURRENTLY "IDX_users_last_name_trgm" ON "users"."users" USING gin ("lastName" gin_trgm_ops)`
 		);
 	}
 
 	public async down(queryRunner: QueryRunner): Promise<void> {
-		await queryRunner.query(`DROP INDEX "users"."IDX_users_last_name_trgm"`);
-		await queryRunner.query(`DROP INDEX "users"."IDX_users_first_name_trgm"`);
-		await queryRunner.query(`DROP INDEX "users"."IDX_contacts_contact_id"`);
-		await queryRunner.query(`DROP INDEX "users"."IDX_blocked_users_blocked_id"`);
+		await queryRunner.query(`DROP INDEX CONCURRENTLY "users"."IDX_users_last_name_trgm"`);
+		await queryRunner.query(`DROP INDEX CONCURRENTLY "users"."IDX_users_first_name_trgm"`);
+		await queryRunner.query(`DROP INDEX CONCURRENTLY "users"."IDX_contacts_contact_id"`);
+		await queryRunner.query(`DROP INDEX CONCURRENTLY "users"."IDX_blocked_users_blocked_id"`);
 	}
 }

--- a/src/database/migrations/__tests__/AddSecondaryIndexes.spec.ts
+++ b/src/database/migrations/__tests__/AddSecondaryIndexes.spec.ts
@@ -1,0 +1,68 @@
+import { QueryRunner } from 'typeorm';
+import { AddSecondaryIndexes1775500200000 } from '../1775500200000-AddSecondaryIndexes';
+
+describe('AddSecondaryIndexes1775500200000', () => {
+	let migration: AddSecondaryIndexes1775500200000;
+	let queryRunner: QueryRunner;
+
+	beforeEach(() => {
+		migration = new AddSecondaryIndexes1775500200000();
+		queryRunner = { query: jest.fn() } as unknown as QueryRunner;
+	});
+
+	it('should have transaction disabled', () => {
+		expect(migration.transaction).toBe(false);
+	});
+
+	describe('up', () => {
+		it('should create all indexes and the pg_trgm extension', async () => {
+			await migration.up(queryRunner);
+
+			expect(queryRunner.query).toHaveBeenCalledTimes(5);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				1,
+				`CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_blocked_users_blocked_id" ON "users"."blocked_users" ("blocked_id")`
+			);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				2,
+				`CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_contacts_contact_id" ON "users"."contacts" ("contact_id")`
+			);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				3,
+				`CREATE EXTENSION IF NOT EXISTS "pg_trgm" WITH SCHEMA public`
+			);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				4,
+				`CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_users_first_name_trgm" ON "users"."users" USING gin ("firstName" gin_trgm_ops)`
+			);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				5,
+				`CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_users_last_name_trgm" ON "users"."users" USING gin ("lastName" gin_trgm_ops)`
+			);
+		});
+	});
+
+	describe('down', () => {
+		it('should drop all indexes in reverse order', async () => {
+			await migration.down(queryRunner);
+
+			expect(queryRunner.query).toHaveBeenCalledTimes(4);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				1,
+				`DROP INDEX CONCURRENTLY IF EXISTS "users"."IDX_users_last_name_trgm"`
+			);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				2,
+				`DROP INDEX CONCURRENTLY IF EXISTS "users"."IDX_users_first_name_trgm"`
+			);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				3,
+				`DROP INDEX CONCURRENTLY IF EXISTS "users"."IDX_contacts_contact_id"`
+			);
+			expect(queryRunner.query).toHaveBeenNthCalledWith(
+				4,
+				`DROP INDEX CONCURRENTLY IF EXISTS "users"."IDX_blocked_users_blocked_id"`
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary\n- Add B-tree index on `blocked_users(blocked_id)` for reverse lookups (\"am I blocked by X?\")\n- Add B-tree index on `contacts(contact_id)` for reverse lookups\n- Enable `pg_trgm` extension and add GIN trigram indexes on `users.firstName` and `users.lastName` for fast ILIKE pattern searches\n\n## Test plan\n- [x] Unit tests green (437/437)\n- [x] E2E tests green (2/2)\n- [x] Lint clean\n\nCloses WHISPR-830