### PR TITLE
[WHISPR-821] feat(profile): add UserResponseDto and remove profilePictureUrl from UpdateProfileDto

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
 			"**/*.(t|j)s",
 			"!**/*.interface.ts",
 			"!**/*.enum.ts",
-			"!**/*.dto.ts",
 			"!**/main.ts",
 			"!**/*.module.ts"
 		],

--- a/src/modules/common/dto/user-response.dto.spec.ts
+++ b/src/modules/common/dto/user-response.dto.spec.ts
@@ -1,0 +1,104 @@
+import { UserResponseDto } from './user-response.dto';
+import { User } from '../entities/user.entity';
+
+describe('UserResponseDto', () => {
+	describe('fromEntity', () => {
+		it('maps all exposed fields from a User entity', () => {
+			const now = new Date();
+			const user = {
+				id: '123e4567-e89b-12d3-a456-426614174000',
+				phoneNumber: '+33612345678',
+				username: 'alice',
+				firstName: 'Alice',
+				lastName: 'Smith',
+				biography: 'Hello world',
+				profilePictureUrl: 'https://example.com/pic.jpg',
+				lastSeen: now,
+				isActive: true,
+				createdAt: now,
+				updatedAt: now,
+			} as User;
+
+			const dto = UserResponseDto.fromEntity(user);
+
+			expect(dto).toBeInstanceOf(UserResponseDto);
+			expect(dto.id).toBe(user.id);
+			expect(dto.username).toBe('alice');
+			expect(dto.firstName).toBe('Alice');
+			expect(dto.lastName).toBe('Smith');
+			expect(dto.biography).toBe('Hello world');
+			expect(dto.profilePictureUrl).toBe('https://example.com/pic.jpg');
+			expect(dto.lastSeen).toBe(now);
+			expect(dto.createdAt).toBe(now);
+			expect(dto.updatedAt).toBe(now);
+		});
+
+		it('excludes internal fields (phoneNumber, isActive)', () => {
+			const user = {
+				id: 'user-1',
+				phoneNumber: '+33612345678',
+				username: 'bob',
+				firstName: null,
+				lastName: null,
+				biography: null,
+				profilePictureUrl: null,
+				lastSeen: null,
+				isActive: false,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			} as unknown as User;
+
+			const dto = UserResponseDto.fromEntity(user);
+
+			expect((dto as any).phoneNumber).toBeUndefined();
+			expect((dto as any).isActive).toBeUndefined();
+		});
+
+		it('coerces undefined nullable fields to null', () => {
+			const user = {
+				id: 'user-2',
+				phoneNumber: '+33600000000',
+				username: 'charlie',
+				firstName: 'Charlie',
+				lastName: 'Brown',
+				biography: undefined,
+				profilePictureUrl: undefined,
+				lastSeen: undefined,
+				isActive: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			} as unknown as User;
+
+			const dto = UserResponseDto.fromEntity(user);
+
+			expect(dto.biography).toBeNull();
+			expect(dto.profilePictureUrl).toBeNull();
+			expect(dto.lastSeen).toBeNull();
+		});
+
+		it('preserves null values for nullable string fields', () => {
+			const user = {
+				id: 'user-3',
+				phoneNumber: '+33600000001',
+				username: null,
+				firstName: null,
+				lastName: null,
+				biography: null,
+				profilePictureUrl: null,
+				lastSeen: null,
+				isActive: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			} as unknown as User;
+
+			const dto = UserResponseDto.fromEntity(user);
+
+			expect(dto.username).toBeNull();
+			expect(dto.firstName).toBeNull();
+			expect(dto.lastName).toBeNull();
+			expect(dto.biography).toBeNull();
+			expect(dto.profilePictureUrl).toBeNull();
+			expect(dto.lastSeen).toBeNull();
+		});
+	});
+});

--- a/src/modules/common/dto/user-response.dto.ts
+++ b/src/modules/common/dto/user-response.dto.ts
@@ -5,22 +5,22 @@ export class UserResponseDto {
 	@ApiProperty()
 	id: string;
 
-	@ApiPropertyOptional()
+	@ApiPropertyOptional({ nullable: true })
 	username: string | null;
 
-	@ApiPropertyOptional()
+	@ApiPropertyOptional({ nullable: true })
 	firstName: string | null;
 
-	@ApiPropertyOptional()
+	@ApiPropertyOptional({ nullable: true })
 	lastName: string | null;
 
-	@ApiPropertyOptional()
+	@ApiPropertyOptional({ nullable: true })
 	biography: string | null;
 
-	@ApiPropertyOptional()
+	@ApiPropertyOptional({ nullable: true })
 	profilePictureUrl: string | null;
 
-	@ApiPropertyOptional()
+	@ApiPropertyOptional({ nullable: true })
 	lastSeen: Date | null;
 
 	@ApiProperty()

--- a/src/modules/common/dto/user-response.dto.ts
+++ b/src/modules/common/dto/user-response.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { User } from '../entities/user.entity';
+
+export class UserResponseDto {
+	@ApiProperty()
+	id: string;
+
+	@ApiPropertyOptional()
+	username: string | null;
+
+	@ApiPropertyOptional()
+	firstName: string | null;
+
+	@ApiPropertyOptional()
+	lastName: string | null;
+
+	@ApiPropertyOptional()
+	biography: string | null;
+
+	@ApiPropertyOptional()
+	profilePictureUrl: string | null;
+
+	@ApiPropertyOptional()
+	lastSeen: Date | null;
+
+	@ApiProperty()
+	createdAt: Date;
+
+	@ApiProperty()
+	updatedAt: Date;
+
+	static fromEntity(user: User): UserResponseDto {
+		const dto = new UserResponseDto();
+		dto.id = user.id;
+		dto.username = user.username;
+		dto.firstName = user.firstName;
+		dto.lastName = user.lastName;
+		dto.biography = user.biography ?? null;
+		dto.profilePictureUrl = user.profilePictureUrl ?? null;
+		dto.lastSeen = user.lastSeen ?? null;
+		dto.createdAt = user.createdAt;
+		dto.updatedAt = user.updatedAt;
+		return dto;
+	}
+}

--- a/src/modules/profile/controllers/profile.controller.spec.ts
+++ b/src/modules/profile/controllers/profile.controller.spec.ts
@@ -36,13 +36,20 @@ describe('ProfileController', () => {
 	});
 
 	describe('getProfile', () => {
-		it('delegates to the service', async () => {
-			const user = { id: 'user-1' } as User;
+		it('delegates to the service and returns a UserResponseDto', async () => {
+			const user = {
+				id: 'user-1',
+				username: 'alice',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			} as User;
 			service.getProfile.mockResolvedValue(user);
 
 			const result = await controller.getProfile('user-1');
 
-			expect(result).toBe(user);
+			expect(result.id).toBe('user-1');
+			expect(result.username).toBe('alice');
+			expect((result as any).phoneNumber).toBeUndefined();
 			expect(service.getProfile).toHaveBeenCalledWith('user-1');
 		});
 	});
@@ -50,12 +57,18 @@ describe('ProfileController', () => {
 	describe('updateProfile', () => {
 		it('updates the profile when the caller is the owner and forwards the authorization header', async () => {
 			const dto: UpdateProfileDto = { username: 'alice' } as UpdateProfileDto;
-			const updated = { id: 'user-1' } as User;
+			const updated = {
+				id: 'user-1',
+				username: 'alice',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			} as User;
 			service.updateProfile.mockResolvedValue(updated);
 
 			const result = await controller.updateProfile('user-1', dto, makeReq('user-1', 'Bearer token'));
 
-			expect(result).toBe(updated);
+			expect(result.id).toBe('user-1');
+			expect((result as any).phoneNumber).toBeUndefined();
 			expect(service.updateProfile).toHaveBeenCalledWith('user-1', dto, 'Bearer token');
 		});
 

--- a/src/modules/profile/controllers/profile.controller.ts
+++ b/src/modules/profile/controllers/profile.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Patch, Param, Body, ParseUUIDPipe, HttpStatus, Request
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
 import { ProfileService } from '../services/profile.service';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
-import { User } from '../../common/entities/user.entity';
+import { UserResponseDto } from '../../common/dto/user-response.dto';
 import type { Request as ExpressRequest } from 'express';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
 import { assertOwnership } from '../../jwt-auth/ownership.util';
@@ -16,17 +16,26 @@ export class ProfileController {
 	@Get(':id')
 	@ApiOperation({ summary: 'Get user profile' })
 	@ApiParam({ name: 'id', type: 'string', format: 'uuid', description: 'User ID' })
-	@ApiResponse({ status: HttpStatus.OK, description: 'Profile retrieved successfully' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Profile retrieved successfully',
+		type: UserResponseDto,
+	})
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async getProfile(@Param('id', ParseUUIDPipe) id: string): Promise<User> {
-		return this.profileService.getProfile(id);
+	async getProfile(@Param('id', ParseUUIDPipe) id: string): Promise<UserResponseDto> {
+		const user = await this.profileService.getProfile(id);
+		return UserResponseDto.fromEntity(user);
 	}
 
 	@Patch(':id')
 	@ApiOperation({ summary: 'Update own profile' })
 	@ApiParam({ name: 'id', type: 'string', format: 'uuid', description: 'User ID' })
-	@ApiResponse({ status: HttpStatus.OK, description: 'Profile updated successfully' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Profile updated successfully',
+		type: UserResponseDto,
+	})
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.CONFLICT, description: 'Username already taken' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
@@ -35,9 +44,10 @@ export class ProfileController {
 		@Param('id', ParseUUIDPipe) id: string,
 		@Body() dto: UpdateProfileDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
-	): Promise<User> {
+	): Promise<UserResponseDto> {
 		assertOwnership(req, id, "Cannot update another user's profile");
 		const authorization = (req.headers['authorization'] as string | undefined) ?? undefined;
-		return this.profileService.updateProfile(id, dto, authorization);
+		const user = await this.profileService.updateProfile(id, dto, authorization);
+		return UserResponseDto.fromEntity(user);
 	}
 }

--- a/src/modules/profile/dto/update-profile.dto.ts
+++ b/src/modules/profile/dto/update-profile.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsUUID, MaxLength, IsUrl } from 'class-validator';
+import { IsString, IsOptional, IsUUID, MaxLength } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateProfileDto {
@@ -24,12 +24,6 @@ export class UpdateProfileDto {
 	@IsOptional()
 	@IsString()
 	biography?: string;
-
-	@ApiPropertyOptional({ description: 'Profile picture URL', maxLength: 500 })
-	@IsOptional()
-	@IsUrl()
-	@MaxLength(500)
-	profilePictureUrl?: string;
 
 	@ApiPropertyOptional({
 		description:

--- a/src/modules/profile/services/profile.service.spec.ts
+++ b/src/modules/profile/services/profile.service.spec.ts
@@ -192,18 +192,6 @@ describe('ProfileService', () => {
 			expect(result.profilePictureUrl).toBe(metadata.url);
 		});
 
-		it('throws BadRequestException when both avatarMediaId and profilePictureUrl are provided', async () => {
-			const user = mockUser();
-			const dto: UpdateProfileDto = {
-				avatarMediaId: 'media-uuid-1',
-				profilePictureUrl: 'https://example.com/photo.jpg',
-			};
-
-			userRepository.findById.mockResolvedValue(user);
-
-			await expect(service.updateProfile('uuid-1', dto)).rejects.toThrow(BadRequestException);
-		});
-
 		it('throws BadRequestException when media context is not avatar', async () => {
 			const user = mockUser();
 			const metadata = mockMediaMetadata({ context: 'message' });

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -52,9 +52,6 @@ export class ProfileService {
 
 		// Resolve avatarMediaId → profilePictureUrl via media-service
 		if (dto.avatarMediaId) {
-			if (dto.profilePictureUrl) {
-				throw new BadRequestException('Cannot provide both avatarMediaId and profilePictureUrl');
-			}
 			const media = await this.mediaClient.getMediaMetadata(dto.avatarMediaId, id, authorization);
 			if (media.context !== 'avatar') {
 				throw new BadRequestException(
@@ -64,7 +61,7 @@ export class ProfileService {
 			if (media.ownerId !== id) {
 				throw new BadRequestException('Media does not belong to this user');
 			}
-			dto.profilePictureUrl = media.url;
+			user.profilePictureUrl = media.url;
 		}
 
 		// Remove avatarMediaId before saving — it's not a DB column


### PR DESCRIPTION
## Summary\n- Add `UserResponseDto` that strips internal fields (`phoneNumber`, `isActive`, `deletedAt`) from API responses\n- Remove `profilePictureUrl` from `UpdateProfileDto` -- clients must use `avatarMediaId` exclusively\n- Profile controller now returns `UserResponseDto.fromEntity()` instead of raw entities\n\n## Test plan\n- [x] Unit tests green (436/436)\n- [x] E2E tests green (2/2)\n- [x] Lint clean\n\nCloses WHISPR-821