### PR TITLE
[WHISPR-823] refactor(api): remove redundant :ownerId parameter, use JWT sub claim

### DIFF
--- a/src/modules/blocked-users/controllers/blocked-users.controller.spec.ts
+++ b/src/modules/blocked-users/controllers/blocked-users.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException } from '@nestjs/common';
 import { BlockedUsersController } from './blocked-users.controller';
 import { BlockedUsersService } from '../services/blocked-users.service';
 import { BlockedUser } from '../entities/blocked-user.entity';
@@ -31,56 +30,37 @@ describe('BlockedUsersController', () => {
 	});
 
 	describe('getBlockedUsers', () => {
-		it('delegates to the service', async () => {
+		it('delegates to the service using req.user.sub as blockerId', async () => {
 			const rows = [{ id: 'b1' }] as BlockedUser[];
 			service.getBlockedUsers.mockResolvedValue(rows);
 
-			const result = await controller.getBlockedUsers('blocker-1', makeReq('blocker-1'));
+			const result = await controller.getBlockedUsers(makeReq('blocker-1'));
 
 			expect(result).toBe(rows);
 			expect(service.getBlockedUsers).toHaveBeenCalledWith('blocker-1');
 		});
-
-		it('throws ForbiddenException when caller is not the owner', async () => {
-			await expect(controller.getBlockedUsers('blocker-1', makeReq('attacker'))).rejects.toThrow(
-				ForbiddenException
-			);
-		});
 	});
 
 	describe('blockUser', () => {
-		it('delegates to the service', async () => {
+		it('delegates to the service using req.user.sub as blockerId', async () => {
 			const dto: BlockUserDto = { blockedId: 'blocked-1' } as BlockUserDto;
 			const created = { id: 'b1' } as BlockedUser;
 			service.blockUser.mockResolvedValue(created);
 
-			const result = await controller.blockUser('blocker-1', dto, makeReq('blocker-1'));
+			const result = await controller.blockUser(dto, makeReq('blocker-1'));
 
 			expect(result).toBe(created);
 			expect(service.blockUser).toHaveBeenCalledWith('blocker-1', dto);
 		});
-
-		it('throws ForbiddenException when caller is not the owner', async () => {
-			const dto: BlockUserDto = { blockedId: 'blocked-1' } as BlockUserDto;
-			await expect(controller.blockUser('blocker-1', dto, makeReq('attacker'))).rejects.toThrow(
-				ForbiddenException
-			);
-		});
 	});
 
 	describe('unblockUser', () => {
-		it('delegates to the service', async () => {
+		it('delegates to the service using req.user.sub as blockerId', async () => {
 			service.unblockUser.mockResolvedValue(undefined);
 
-			await controller.unblockUser('blocker-1', 'blocked-1', makeReq('blocker-1'));
+			await controller.unblockUser('blocked-1', makeReq('blocker-1'));
 
 			expect(service.unblockUser).toHaveBeenCalledWith('blocker-1', 'blocked-1');
-		});
-
-		it('throws ForbiddenException when caller is not the owner', async () => {
-			await expect(
-				controller.unblockUser('blocker-1', 'blocked-1', makeReq('attacker'))
-			).rejects.toThrow(ForbiddenException);
 		});
 	});
 });

--- a/src/modules/blocked-users/controllers/blocked-users.controller.ts
+++ b/src/modules/blocked-users/controllers/blocked-users.controller.ts
@@ -16,7 +16,6 @@ import { BlockUserDto } from '../dto/block-user.dto';
 import { BlockedUser } from '../entities/blocked-user.entity';
 import type { Request as ExpressRequest } from 'express';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
-import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Blocked Users')
 @ApiBearerAuth()
@@ -24,48 +23,39 @@ import { assertOwnership } from '../../jwt-auth/ownership.util';
 export class BlockedUsersController {
 	constructor(private readonly blockedUsersService: BlockedUsersService) {}
 
-	@Get(':blockerId')
-	@ApiOperation({ summary: 'Get all blocked users for a user' })
-	@ApiParam({ name: 'blockerId', type: 'string', format: 'uuid', description: 'Blocker user ID' })
+	@Get()
+	@ApiOperation({ summary: 'Get all blocked users for the authenticated user' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Blocked users retrieved successfully' })
-	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
-	async getBlockedUsers(
-		@Param('blockerId', ParseUUIDPipe) blockerId: string,
-		@Request() req: ExpressRequest & { user: JwtPayload }
-	): Promise<BlockedUser[]> {
-		assertOwnership(req, blockerId);
-		return this.blockedUsersService.getBlockedUsers(blockerId);
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
+	async getBlockedUsers(@Request() req: ExpressRequest & { user: JwtPayload }): Promise<BlockedUser[]> {
+		return this.blockedUsersService.getBlockedUsers(req.user.sub);
 	}
 
-	@Post(':blockerId')
+	@Post()
 	@ApiOperation({ summary: 'Block a user' })
-	@ApiParam({ name: 'blockerId', type: 'string', format: 'uuid', description: 'Blocker user ID' })
 	@ApiResponse({ status: HttpStatus.CREATED, description: 'User blocked successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.CONFLICT, description: 'User is already blocked' })
 	@ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Cannot block yourself' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async blockUser(
-		@Param('blockerId', ParseUUIDPipe) blockerId: string,
 		@Body() dto: BlockUserDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<BlockedUser> {
-		assertOwnership(req, blockerId);
-		return this.blockedUsersService.blockUser(blockerId, dto);
+		return this.blockedUsersService.blockUser(req.user.sub, dto);
 	}
 
-	@Delete(':blockerId/:blockedId')
+	@Delete(':blockedId')
 	@HttpCode(HttpStatus.NO_CONTENT)
 	@ApiOperation({ summary: 'Unblock a user' })
-	@ApiParam({ name: 'blockerId', type: 'string', format: 'uuid', description: 'Blocker user ID' })
 	@ApiParam({ name: 'blockedId', type: 'string', format: 'uuid', description: 'Blocked user ID' })
 	@ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'User unblocked successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User or blocked entry not found' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async unblockUser(
-		@Param('blockerId', ParseUUIDPipe) blockerId: string,
 		@Param('blockedId', ParseUUIDPipe) blockedId: string,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<void> {
-		assertOwnership(req, blockerId);
-		return this.blockedUsersService.unblockUser(blockerId, blockedId);
+		return this.blockedUsersService.unblockUser(req.user.sub, blockedId);
 	}
 }

--- a/src/modules/blocked-users/controllers/blocked-users.controller.ts
+++ b/src/modules/blocked-users/controllers/blocked-users.controller.ts
@@ -26,6 +26,7 @@ export class BlockedUsersController {
 	@Get()
 	@ApiOperation({ summary: 'Get all blocked users for the authenticated user' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Blocked users retrieved successfully' })
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async getBlockedUsers(@Request() req: ExpressRequest & { user: JwtPayload }): Promise<BlockedUser[]> {
 		return this.blockedUsersService.getBlockedUsers(req.user.sub);

--- a/src/modules/contacts/controllers/contact-requests.controller.spec.ts
+++ b/src/modules/contacts/controllers/contact-requests.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException } from '@nestjs/common';
 import type { Request as ExpressRequest } from 'express';
 import { ContactRequestsController } from './contact-requests.controller';
 import { ContactRequestsService } from '../services/contact-requests.service';
@@ -57,21 +56,14 @@ describe('ContactRequestsController', () => {
 	});
 
 	describe('getRequests', () => {
-		it('returns requests when the caller owns them', async () => {
+		it('returns requests for the authenticated user', async () => {
 			const requests = [mockRequest()];
 			service.getRequestsForUser.mockResolvedValue(requests);
 
-			const result = await controller.getRequests('uuid-a', makeReq('uuid-a'));
+			const result = await controller.getRequests(makeReq('uuid-a'));
 
 			expect(result).toBe(requests);
 			expect(service.getRequestsForUser).toHaveBeenCalledWith('uuid-a');
-		});
-
-		it('throws Forbidden when the caller targets another user', async () => {
-			await expect(controller.getRequests('uuid-a', makeReq('uuid-b'))).rejects.toThrow(
-				ForbiddenException
-			);
-			expect(service.getRequestsForUser).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/modules/contacts/controllers/contact-requests.controller.ts
+++ b/src/modules/contacts/controllers/contact-requests.controller.ts
@@ -17,7 +17,6 @@ import { ContactRequestsService } from '../services/contact-requests.service';
 import { SendContactRequestDto } from '../dto/send-contact-request.dto';
 import { ContactRequest } from '../entities/contact-request.entity';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
-import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Contact Requests')
 @ApiBearerAuth()
@@ -42,22 +41,12 @@ export class ContactRequestsController {
 		return this.contactRequestsService.sendRequest(req.user.sub, dto.contactId);
 	}
 
-	@Get(':userId')
-	@ApiOperation({ summary: 'Get all contact requests for a user (incoming + outgoing)' })
-	@ApiParam({ name: 'userId', type: 'string', format: 'uuid', description: 'User ID' })
+	@Get()
+	@ApiOperation({ summary: 'Get all contact requests for the authenticated user (incoming + outgoing)' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Contact requests retrieved successfully' })
-	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	@ApiResponse({
-		status: HttpStatus.FORBIDDEN,
-		description: "Cannot access another user's contact requests",
-	})
-	async getRequests(
-		@Param('userId', ParseUUIDPipe) userId: string,
-		@Request() req: ExpressRequest & { user: JwtPayload }
-	): Promise<ContactRequest[]> {
-		assertOwnership(req, userId, "Cannot access another user's contact requests");
-		return this.contactRequestsService.getRequestsForUser(userId);
+	async getRequests(@Request() req: ExpressRequest & { user: JwtPayload }): Promise<ContactRequest[]> {
+		return this.contactRequestsService.getRequestsForUser(req.user.sub);
 	}
 
 	@Patch(':requestId/accept')

--- a/src/modules/contacts/controllers/contact-requests.controller.ts
+++ b/src/modules/contacts/controllers/contact-requests.controller.ts
@@ -44,6 +44,7 @@ export class ContactRequestsController {
 	@Get()
 	@ApiOperation({ summary: 'Get all contact requests for the authenticated user (incoming + outgoing)' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Contact requests retrieved successfully' })
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async getRequests(@Request() req: ExpressRequest & { user: JwtPayload }): Promise<ContactRequest[]> {
 		return this.contactRequestsService.getRequestsForUser(req.user.sub);

--- a/src/modules/contacts/controllers/contacts.controller.spec.ts
+++ b/src/modules/contacts/controllers/contacts.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException } from '@nestjs/common';
 import type { Request as ExpressRequest } from 'express';
 import { ContactsController } from './contacts.controller';
 import { ContactsService } from '../services/contacts.service';
@@ -36,80 +35,50 @@ describe('ContactsController', () => {
 	});
 
 	describe('getContacts', () => {
-		it('returns the contacts when the caller owns them', async () => {
+		it('returns the contacts for the authenticated user', async () => {
 			const contacts = [{ id: 'c1' }] as Contact[];
 			service.getContacts.mockResolvedValue(contacts);
 
-			const result = await controller.getContacts('owner-1', makeReq('owner-1'));
+			const result = await controller.getContacts(makeReq('owner-1'));
 
 			expect(result).toBe(contacts);
 			expect(service.getContacts).toHaveBeenCalledWith('owner-1');
 		});
-
-		it('throws Forbidden when the caller targets another user', async () => {
-			await expect(controller.getContacts('owner-1', makeReq('other'))).rejects.toThrow(
-				ForbiddenException
-			);
-			expect(service.getContacts).not.toHaveBeenCalled();
-		});
 	});
 
 	describe('addContact', () => {
-		it('delegates to the service for the caller', async () => {
+		it('delegates to the service using req.user.sub as ownerId', async () => {
 			const dto: AddContactDto = { contactId: 'contact-1' } as AddContactDto;
 			const created = { id: 'c1' } as Contact;
 			service.addContact.mockResolvedValue(created);
 
-			const result = await controller.addContact('owner-1', dto, makeReq('owner-1'));
+			const result = await controller.addContact(dto, makeReq('owner-1'));
 
 			expect(result).toBe(created);
 			expect(service.addContact).toHaveBeenCalledWith('owner-1', dto);
 		});
-
-		it('throws Forbidden when the caller targets another user', async () => {
-			const dto: AddContactDto = { contactId: 'contact-1' } as AddContactDto;
-
-			await expect(controller.addContact('owner-1', dto, makeReq('other'))).rejects.toThrow(
-				ForbiddenException
-			);
-			expect(service.addContact).not.toHaveBeenCalled();
-		});
 	});
 
 	describe('updateContact', () => {
-		it('delegates to the service for the caller', async () => {
+		it('delegates to the service using req.user.sub as ownerId', async () => {
 			const dto: UpdateContactDto = { nickname: 'Bob' } as UpdateContactDto;
 			const updated = { id: 'c1', nickname: 'Bob' } as Contact;
 			service.updateContact.mockResolvedValue(updated);
 
-			const result = await controller.updateContact('owner-1', 'contact-1', dto, makeReq('owner-1'));
+			const result = await controller.updateContact('contact-1', dto, makeReq('owner-1'));
 
 			expect(result).toBe(updated);
 			expect(service.updateContact).toHaveBeenCalledWith('owner-1', 'contact-1', dto);
 		});
-
-		it('throws Forbidden when the caller targets another user', async () => {
-			await expect(
-				controller.updateContact('owner-1', 'contact-1', {} as UpdateContactDto, makeReq('other'))
-			).rejects.toThrow(ForbiddenException);
-			expect(service.updateContact).not.toHaveBeenCalled();
-		});
 	});
 
 	describe('removeContact', () => {
-		it('delegates to the service for the caller', async () => {
+		it('delegates to the service using req.user.sub as ownerId', async () => {
 			service.removeContact.mockResolvedValue(undefined);
 
-			await controller.removeContact('owner-1', 'contact-1', makeReq('owner-1'));
+			await controller.removeContact('contact-1', makeReq('owner-1'));
 
 			expect(service.removeContact).toHaveBeenCalledWith('owner-1', 'contact-1');
-		});
-
-		it('throws Forbidden when the caller targets another user', async () => {
-			await expect(controller.removeContact('owner-1', 'contact-1', makeReq('other'))).rejects.toThrow(
-				ForbiddenException
-			);
-			expect(service.removeContact).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/modules/contacts/controllers/contacts.controller.ts
+++ b/src/modules/contacts/controllers/contacts.controller.ts
@@ -28,6 +28,7 @@ export class ContactsController {
 	@Get()
 	@ApiOperation({ summary: 'Get all contacts for the authenticated user' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Contacts retrieved successfully' })
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async getContacts(@Request() req: ExpressRequest & { user: JwtPayload }): Promise<Contact[]> {
 		return this.contactsService.getContacts(req.user.sub);

--- a/src/modules/contacts/controllers/contacts.controller.ts
+++ b/src/modules/contacts/controllers/contacts.controller.ts
@@ -18,7 +18,6 @@ import { AddContactDto } from '../dto/add-contact.dto';
 import { UpdateContactDto } from '../dto/update-contact.dto';
 import { Contact } from '../entities/contact.entity';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
-import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Contacts')
 @ApiBearerAuth()
@@ -26,72 +25,53 @@ import { assertOwnership } from '../../jwt-auth/ownership.util';
 export class ContactsController {
 	constructor(private readonly contactsService: ContactsService) {}
 
-	@Get(':ownerId')
-	@ApiOperation({ summary: 'Get all contacts for a user' })
-	@ApiParam({ name: 'ownerId', type: 'string', format: 'uuid', description: 'Owner user ID' })
+	@Get()
+	@ApiOperation({ summary: 'Get all contacts for the authenticated user' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Contacts retrieved successfully' })
-	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	@ApiResponse({ status: HttpStatus.FORBIDDEN, description: "Cannot access another user's contacts" })
-	async getContacts(
-		@Param('ownerId', ParseUUIDPipe) ownerId: string,
-		@Request() req: ExpressRequest & { user: JwtPayload }
-	): Promise<Contact[]> {
-		assertOwnership(req, ownerId, "Cannot access another user's contacts");
-		return this.contactsService.getContacts(ownerId);
+	async getContacts(@Request() req: ExpressRequest & { user: JwtPayload }): Promise<Contact[]> {
+		return this.contactsService.getContacts(req.user.sub);
 	}
 
-	@Post(':ownerId')
-	@ApiOperation({ summary: 'Add a contact for a user' })
-	@ApiParam({ name: 'ownerId', type: 'string', format: 'uuid', description: 'Owner user ID' })
+	@Post()
+	@ApiOperation({ summary: 'Add a contact for the authenticated user' })
 	@ApiResponse({ status: HttpStatus.CREATED, description: 'Contact added successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.CONFLICT, description: 'Contact already exists' })
 	@ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Cannot add yourself as a contact' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	@ApiResponse({ status: HttpStatus.FORBIDDEN, description: "Cannot access another user's contacts" })
 	async addContact(
-		@Param('ownerId', ParseUUIDPipe) ownerId: string,
 		@Body() dto: AddContactDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<Contact> {
-		assertOwnership(req, ownerId, "Cannot access another user's contacts");
-		return this.contactsService.addContact(ownerId, dto);
+		return this.contactsService.addContact(req.user.sub, dto);
 	}
 
-	@Patch(':ownerId/:contactId')
-	@ApiOperation({ summary: 'Update a contact for a user' })
-	@ApiParam({ name: 'ownerId', type: 'string', format: 'uuid', description: 'Owner user ID' })
+	@Patch(':contactId')
+	@ApiOperation({ summary: 'Update a contact for the authenticated user' })
 	@ApiParam({ name: 'contactId', type: 'string', format: 'uuid', description: 'Contact user ID' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Contact updated successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User or contact not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	@ApiResponse({ status: HttpStatus.FORBIDDEN, description: "Cannot access another user's contacts" })
 	async updateContact(
-		@Param('ownerId', ParseUUIDPipe) ownerId: string,
 		@Param('contactId', ParseUUIDPipe) contactId: string,
 		@Body() dto: UpdateContactDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<Contact> {
-		assertOwnership(req, ownerId, "Cannot access another user's contacts");
-		return this.contactsService.updateContact(ownerId, contactId, dto);
+		return this.contactsService.updateContact(req.user.sub, contactId, dto);
 	}
 
-	@Delete(':ownerId/:contactId')
+	@Delete(':contactId')
 	@HttpCode(HttpStatus.NO_CONTENT)
-	@ApiOperation({ summary: 'Remove a contact for a user' })
-	@ApiParam({ name: 'ownerId', type: 'string', format: 'uuid', description: 'Owner user ID' })
+	@ApiOperation({ summary: 'Remove a contact for the authenticated user' })
 	@ApiParam({ name: 'contactId', type: 'string', format: 'uuid', description: 'Contact user ID' })
 	@ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'Contact removed successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User or contact not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	@ApiResponse({ status: HttpStatus.FORBIDDEN, description: "Cannot access another user's contacts" })
 	async removeContact(
-		@Param('ownerId', ParseUUIDPipe) ownerId: string,
 		@Param('contactId', ParseUUIDPipe) contactId: string,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<void> {
-		assertOwnership(req, ownerId, "Cannot access another user's contacts");
-		return this.contactsService.removeContact(ownerId, contactId);
+		return this.contactsService.removeContact(req.user.sub, contactId);
 	}
 }

--- a/src/modules/groups/controllers/groups.controller.spec.ts
+++ b/src/modules/groups/controllers/groups.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException } from '@nestjs/common';
 import { GroupsController } from './groups.controller';
 import { GroupsService } from '../services/groups.service';
 import { Group } from '../entities/group.entity';
@@ -33,76 +32,50 @@ describe('GroupsController', () => {
 	});
 
 	describe('getGroups', () => {
-		it('delegates to the service', async () => {
+		it('delegates to the service using req.user.sub as ownerId', async () => {
 			const groups = [{ id: 'g1' }] as Group[];
 			service.getGroups.mockResolvedValue(groups);
 
-			const result = await controller.getGroups('owner-1', makeReq('owner-1'));
+			const result = await controller.getGroups(makeReq('owner-1'));
 
 			expect(result).toBe(groups);
 			expect(service.getGroups).toHaveBeenCalledWith('owner-1');
 		});
-
-		it('throws ForbiddenException when caller is not the owner', async () => {
-			await expect(controller.getGroups('owner-1', makeReq('attacker'))).rejects.toThrow(
-				ForbiddenException
-			);
-		});
 	});
 
 	describe('createGroup', () => {
-		it('delegates to the service', async () => {
+		it('delegates to the service using req.user.sub as ownerId', async () => {
 			const dto: CreateGroupDto = { name: 'Friends' } as CreateGroupDto;
 			const created = { id: 'g1' } as Group;
 			service.createGroup.mockResolvedValue(created);
 
-			const result = await controller.createGroup('owner-1', dto, makeReq('owner-1'));
+			const result = await controller.createGroup(dto, makeReq('owner-1'));
 
 			expect(result).toBe(created);
 			expect(service.createGroup).toHaveBeenCalledWith('owner-1', dto);
 		});
-
-		it('throws ForbiddenException when caller is not the owner', async () => {
-			const dto: CreateGroupDto = { name: 'Friends' } as CreateGroupDto;
-			await expect(controller.createGroup('owner-1', dto, makeReq('attacker'))).rejects.toThrow(
-				ForbiddenException
-			);
-		});
 	});
 
 	describe('updateGroup', () => {
-		it('delegates to the service', async () => {
+		it('delegates to the service using req.user.sub as ownerId', async () => {
 			const dto: UpdateGroupDto = { name: 'Family' } as UpdateGroupDto;
 			const updated = { id: 'g1', name: 'Family' } as Group;
 			service.updateGroup.mockResolvedValue(updated);
 
-			const result = await controller.updateGroup('owner-1', 'g1', dto, makeReq('owner-1'));
+			const result = await controller.updateGroup('g1', dto, makeReq('owner-1'));
 
 			expect(result).toBe(updated);
 			expect(service.updateGroup).toHaveBeenCalledWith('owner-1', 'g1', dto);
 		});
-
-		it('throws ForbiddenException when caller is not the owner', async () => {
-			const dto: UpdateGroupDto = { name: 'Family' } as UpdateGroupDto;
-			await expect(controller.updateGroup('owner-1', 'g1', dto, makeReq('attacker'))).rejects.toThrow(
-				ForbiddenException
-			);
-		});
 	});
 
 	describe('deleteGroup', () => {
-		it('delegates to the service', async () => {
+		it('delegates to the service using req.user.sub as ownerId', async () => {
 			service.deleteGroup.mockResolvedValue(undefined);
 
-			await controller.deleteGroup('owner-1', 'g1', makeReq('owner-1'));
+			await controller.deleteGroup('g1', makeReq('owner-1'));
 
 			expect(service.deleteGroup).toHaveBeenCalledWith('owner-1', 'g1');
-		});
-
-		it('throws ForbiddenException when caller is not the owner', async () => {
-			await expect(controller.deleteGroup('owner-1', 'g1', makeReq('attacker'))).rejects.toThrow(
-				ForbiddenException
-			);
 		});
 	});
 });

--- a/src/modules/groups/controllers/groups.controller.ts
+++ b/src/modules/groups/controllers/groups.controller.ts
@@ -18,7 +18,6 @@ import { UpdateGroupDto } from '../dto/update-group.dto';
 import { Group } from '../entities/group.entity';
 import type { Request as ExpressRequest } from 'express';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
-import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Groups')
 @ApiBearerAuth()
@@ -26,64 +25,53 @@ import { assertOwnership } from '../../jwt-auth/ownership.util';
 export class GroupsController {
 	constructor(private readonly groupsService: GroupsService) {}
 
-	@Get(':ownerId')
-	@ApiOperation({ summary: 'Get all groups for a user' })
-	@ApiParam({ name: 'ownerId', type: 'string', format: 'uuid', description: 'Owner user ID' })
+	@Get()
+	@ApiOperation({ summary: 'Get all groups for the authenticated user' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Groups retrieved successfully' })
-	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
-	async getGroups(
-		@Param('ownerId', ParseUUIDPipe) ownerId: string,
-		@Request() req: ExpressRequest & { user: JwtPayload }
-	): Promise<Group[]> {
-		assertOwnership(req, ownerId);
-		return this.groupsService.getGroups(ownerId);
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
+	async getGroups(@Request() req: ExpressRequest & { user: JwtPayload }): Promise<Group[]> {
+		return this.groupsService.getGroups(req.user.sub);
 	}
 
-	@Post(':ownerId')
-	@ApiOperation({ summary: 'Create a group for a user' })
-	@ApiParam({ name: 'ownerId', type: 'string', format: 'uuid', description: 'Owner user ID' })
+	@Post()
+	@ApiOperation({ summary: 'Create a group for the authenticated user' })
 	@ApiResponse({ status: HttpStatus.CREATED, description: 'Group created successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async createGroup(
-		@Param('ownerId', ParseUUIDPipe) ownerId: string,
 		@Body() dto: CreateGroupDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<Group> {
-		assertOwnership(req, ownerId);
-		return this.groupsService.createGroup(ownerId, dto);
+		return this.groupsService.createGroup(req.user.sub, dto);
 	}
 
-	@Patch(':ownerId/:groupId')
+	@Patch(':groupId')
 	@ApiOperation({ summary: 'Update a group' })
-	@ApiParam({ name: 'ownerId', type: 'string', format: 'uuid', description: 'Owner user ID' })
 	@ApiParam({ name: 'groupId', type: 'string', format: 'uuid', description: 'Group ID' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Group updated successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User or group not found' })
 	@ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'You do not own this group' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async updateGroup(
-		@Param('ownerId', ParseUUIDPipe) ownerId: string,
 		@Param('groupId', ParseUUIDPipe) groupId: string,
 		@Body() dto: UpdateGroupDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<Group> {
-		assertOwnership(req, ownerId);
-		return this.groupsService.updateGroup(ownerId, groupId, dto);
+		return this.groupsService.updateGroup(req.user.sub, groupId, dto);
 	}
 
-	@Delete(':ownerId/:groupId')
+	@Delete(':groupId')
 	@HttpCode(HttpStatus.NO_CONTENT)
 	@ApiOperation({ summary: 'Delete a group' })
-	@ApiParam({ name: 'ownerId', type: 'string', format: 'uuid', description: 'Owner user ID' })
 	@ApiParam({ name: 'groupId', type: 'string', format: 'uuid', description: 'Group ID' })
 	@ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'Group deleted successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User or group not found' })
 	@ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'You do not own this group' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async deleteGroup(
-		@Param('ownerId', ParseUUIDPipe) ownerId: string,
 		@Param('groupId', ParseUUIDPipe) groupId: string,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<void> {
-		assertOwnership(req, ownerId);
-		return this.groupsService.deleteGroup(ownerId, groupId);
+		return this.groupsService.deleteGroup(req.user.sub, groupId);
 	}
 }

--- a/src/modules/groups/controllers/groups.controller.ts
+++ b/src/modules/groups/controllers/groups.controller.ts
@@ -28,6 +28,7 @@ export class GroupsController {
 	@Get()
 	@ApiOperation({ summary: 'Get all groups for the authenticated user' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Groups retrieved successfully' })
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async getGroups(@Request() req: ExpressRequest & { user: JwtPayload }): Promise<Group[]> {
 		return this.groupsService.getGroups(req.user.sub);

--- a/src/modules/privacy/controllers/privacy.controller.spec.ts
+++ b/src/modules/privacy/controllers/privacy.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException } from '@nestjs/common';
 import { PrivacyController } from './privacy.controller';
 import { PrivacyService } from '../services/privacy.service';
 import { PrivacySettings } from '../entities/privacy-settings.entity';
@@ -30,40 +29,27 @@ describe('PrivacyController', () => {
 	});
 
 	describe('getSettings', () => {
-		it('delegates to the service', async () => {
+		it('delegates to the service using req.user.sub as userId', async () => {
 			const settings = { userId: 'user-1' } as PrivacySettings;
 			service.getSettings.mockResolvedValue(settings);
 
-			const result = await controller.getSettings('user-1', makeReq('user-1'));
+			const result = await controller.getSettings(makeReq('user-1'));
 
 			expect(result).toBe(settings);
 			expect(service.getSettings).toHaveBeenCalledWith('user-1');
 		});
-
-		it('throws ForbiddenException when caller is not the owner', async () => {
-			await expect(controller.getSettings('user-1', makeReq('attacker'))).rejects.toThrow(
-				ForbiddenException
-			);
-		});
 	});
 
 	describe('updateSettings', () => {
-		it('delegates to the service', async () => {
+		it('delegates to the service using req.user.sub as userId', async () => {
 			const dto: UpdatePrivacySettingsDto = {} as UpdatePrivacySettingsDto;
 			const updated = { userId: 'user-1' } as PrivacySettings;
 			service.updateSettings.mockResolvedValue(updated);
 
-			const result = await controller.updateSettings('user-1', dto, makeReq('user-1'));
+			const result = await controller.updateSettings(dto, makeReq('user-1'));
 
 			expect(result).toBe(updated);
 			expect(service.updateSettings).toHaveBeenCalledWith('user-1', dto);
-		});
-
-		it('throws ForbiddenException when caller is not the owner', async () => {
-			const dto: UpdatePrivacySettingsDto = {} as UpdatePrivacySettingsDto;
-			await expect(controller.updateSettings('user-1', dto, makeReq('attacker'))).rejects.toThrow(
-				ForbiddenException
-			);
 		});
 	});
 });

--- a/src/modules/privacy/controllers/privacy.controller.ts
+++ b/src/modules/privacy/controllers/privacy.controller.ts
@@ -1,11 +1,10 @@
-import { Controller, Get, Patch, Param, Body, ParseUUIDPipe, HttpStatus, Request } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
+import { Controller, Get, Patch, Body, HttpStatus, Request } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { PrivacyService } from '../services/privacy.service';
 import { UpdatePrivacySettingsDto } from '../dto/update-privacy-settings.dto';
 import { PrivacySettings } from '../entities/privacy-settings.entity';
 import type { Request as ExpressRequest } from 'express';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
-import { assertOwnership } from '../../jwt-auth/ownership.util';
 
 @ApiTags('Privacy')
 @ApiBearerAuth()
@@ -13,32 +12,24 @@ import { assertOwnership } from '../../jwt-auth/ownership.util';
 export class PrivacyController {
 	constructor(private readonly privacyService: PrivacyService) {}
 
-	@Get(':userId')
-	@ApiOperation({ summary: 'Get privacy settings for a user' })
-	@ApiParam({ name: 'userId', type: 'string', format: 'uuid', description: 'User ID' })
+	@Get()
+	@ApiOperation({ summary: 'Get privacy settings for the authenticated user' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Privacy settings retrieved successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async getSettings(
-		@Param('userId', ParseUUIDPipe) userId: string,
-		@Request() req: ExpressRequest & { user: JwtPayload }
-	): Promise<PrivacySettings> {
-		assertOwnership(req, userId);
-		return this.privacyService.getSettings(userId);
+	async getSettings(@Request() req: ExpressRequest & { user: JwtPayload }): Promise<PrivacySettings> {
+		return this.privacyService.getSettings(req.user.sub);
 	}
 
-	@Patch(':userId')
-	@ApiOperation({ summary: 'Update privacy settings for a user' })
-	@ApiParam({ name: 'userId', type: 'string', format: 'uuid', description: 'User ID' })
+	@Patch()
+	@ApiOperation({ summary: 'Update privacy settings for the authenticated user' })
 	@ApiResponse({ status: HttpStatus.OK, description: 'Privacy settings updated successfully' })
 	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
 	async updateSettings(
-		@Param('userId', ParseUUIDPipe) userId: string,
 		@Body() dto: UpdatePrivacySettingsDto,
 		@Request() req: ExpressRequest & { user: JwtPayload }
 	): Promise<PrivacySettings> {
-		assertOwnership(req, userId);
-		return this.privacyService.updateSettings(userId, dto);
+		return this.privacyService.updateSettings(req.user.sub, dto);
 	}
 }


### PR DESCRIPTION
## Summary\n- Remove `:ownerId`, `:blockerId`, `:userId` path parameters from contacts, blocked-users, groups, contact-requests and privacy controllers\n- User identity now comes exclusively from `req.user.sub` (JWT sub claim)\n- Remove all `assertOwnership` calls on these endpoints (IDOR prevented by design)\n- Simplifies API surface and eliminates the confusion that led to prior access control bugs\n\n## Breaking changes\n- `GET /contacts/:ownerId` -> `GET /contacts/`\n- `POST /contacts/:ownerId` -> `POST /contacts/`\n- `PATCH /contacts/:ownerId/:contactId` -> `PATCH /contacts/:contactId`\n- `DELETE /contacts/:ownerId/:contactId` -> `DELETE /contacts/:contactId`\n- Same pattern for blocked-users, groups, contact-requests, privacy\n\n## Test plan\n- [x] Unit tests green (423/423)\n- [x] E2E tests green (2/2)\n- [x] Lint clean\n\nCloses WHISPR-823