### PR TITLE
refactor(cache): ajouter removeStaleIndexKeys pour une suppression ciblée

### DIFF
--- a/src/modules/cache/search-index.service.spec.ts
+++ b/src/modules/cache/search-index.service.spec.ts
@@ -79,6 +79,87 @@ describe('SearchIndexService', () => {
 		});
 	});
 
+	describe('removeStaleIndexKeys', () => {
+		it('is a no-op when no indexed field changed', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const oldUser = makeUser();
+			const newUser = makeUser({ biography: 'updated bio' } as any);
+
+			await service.removeStaleIndexKeys(oldUser, newUser);
+
+			expect(mockCacheService.pipeline).not.toHaveBeenCalled();
+		});
+
+		it('removes only the old username entry when username changes', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const oldUser = makeUser({ username: 'alice' });
+			const newUser = makeUser({ username: 'bob' });
+
+			await service.removeStaleIndexKeys(oldUser, newUser);
+
+			const [commands] = (mockCacheService.pipeline as jest.Mock).mock.calls[0];
+			expect(commands).toContainEqual(['hdel', 'search:username', 'alice']);
+			expect(commands).not.toContainEqual(['hdel', 'search:username', 'bob']);
+		});
+
+		it('removes old firstName and old fullName indexes when firstName changes', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const oldUser = makeUser({ firstName: 'Alice', lastName: 'Smith' });
+			const newUser = makeUser({ firstName: 'Alicia', lastName: 'Smith' });
+
+			await service.removeStaleIndexKeys(oldUser, newUser);
+
+			const [commands] = (mockCacheService.pipeline as jest.Mock).mock.calls[0];
+			expect(commands).toContainEqual(['zrem', 'search:name:alice', oldUser.id]);
+			expect(commands).toContainEqual(['zrem', 'search:name:alice smith', oldUser.id]);
+			expect(commands).not.toContainEqual(['zrem', 'search:name:smith', oldUser.id]);
+		});
+
+		it('removes old lastName and old fullName indexes when lastName changes', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const oldUser = makeUser({ firstName: 'Alice', lastName: 'Smith' });
+			const newUser = makeUser({ firstName: 'Alice', lastName: 'Johnson' });
+
+			await service.removeStaleIndexKeys(oldUser, newUser);
+
+			const [commands] = (mockCacheService.pipeline as jest.Mock).mock.calls[0];
+			expect(commands).toContainEqual(['zrem', 'search:name:smith', oldUser.id]);
+			expect(commands).toContainEqual(['zrem', 'search:name:alice smith', oldUser.id]);
+			expect(commands).not.toContainEqual(['zrem', 'search:name:alice', oldUser.id]);
+		});
+
+		it('never touches the phone index or the user cache', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const oldUser = makeUser({ username: 'alice', firstName: 'Alice', lastName: 'Smith' });
+			const newUser = makeUser({ username: 'bob', firstName: 'Bob', lastName: 'Johnson' });
+
+			await service.removeStaleIndexKeys(oldUser, newUser);
+
+			const [commands] = (mockCacheService.pipeline as jest.Mock).mock.calls[0];
+			const flatCommands = commands.map((c: any[]) => c[0]);
+			expect(flatCommands).not.toContain('del');
+			expect(commands.find((c: any[]) => c[0] === 'hdel' && c[1] === 'search:phone')).toBeUndefined();
+		});
+
+		it('ignores case changes that normalize to the same key', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const oldUser = makeUser({ username: 'Alice' });
+			const newUser = makeUser({ username: 'ALICE' });
+
+			await service.removeStaleIndexKeys(oldUser, newUser);
+
+			expect(mockCacheService.pipeline).not.toHaveBeenCalled();
+		});
+
+		it('throws when pipeline fails', async () => {
+			mockCacheService.pipeline = jest.fn().mockRejectedValue(new Error('Redis error'));
+			const oldUser = makeUser({ username: 'alice' });
+			const newUser = makeUser({ username: 'bob' });
+
+			await expect(service.removeStaleIndexKeys(oldUser, newUser)).rejects.toThrow('Redis error');
+		});
+	});
+
 	describe('searchByPhoneNumber', () => {
 		it('should return userId from cache', async () => {
 			mockCacheService.hget = jest.fn().mockResolvedValue('user-1');

--- a/src/modules/cache/search-index.service.ts
+++ b/src/modules/cache/search-index.service.ts
@@ -13,6 +13,14 @@ export interface SearchIndexEntry {
 	createdAt: Date;
 }
 
+// Sous-ensemble minimal requis pour les opérations d'indexation sur les champs
+// recherchables d'un utilisateur — évite de copier l'entité complète (relations,
+// champs non pertinents) lorsqu'on veut comparer un "avant" et un "après".
+export type UserIndexSnapshot = Pick<
+	User,
+	'id' | 'phoneNumber' | 'username' | 'firstName' | 'lastName' | 'createdAt'
+>;
+
 @Injectable()
 export class SearchIndexService {
 	private readonly logger = new Logger(SearchIndexService.name);
@@ -120,6 +128,58 @@ export class SearchIndexService {
 			this.logger.debug(`Removed user ${user.id} from search indexes`);
 		} catch (error) {
 			this.logger.error(`Failed to remove user ${user.id} from indexes:`, error);
+			throw error;
+		}
+	}
+
+	// Supprime uniquement les entrées d'index dont la valeur a changé entre
+	// `oldUser` et `newUser`. Contrairement à `removeUserFromIndex`, cette
+	// méthode ne touche ni au hash `search:phone` ni au cache `user:cache:<id>`
+	// (ils restent valides lors d'une mise à jour de profil car le numéro de
+	// téléphone n'est pas modifié et `indexUser` réécrit déjà le cache).
+	async removeStaleIndexKeys(oldUser: UserIndexSnapshot, newUser: UserIndexSnapshot): Promise<void> {
+		try {
+			const oldUsername = oldUser.username?.toLowerCase();
+			const newUsername = newUser.username?.toLowerCase();
+			const oldFirstName = oldUser.firstName?.toLowerCase();
+			const newFirstName = newUser.firstName?.toLowerCase();
+			const oldLastName = oldUser.lastName?.toLowerCase();
+			const newLastName = newUser.lastName?.toLowerCase();
+
+			const oldFullName = [oldUser.firstName, oldUser.lastName]
+				.filter((p): p is string => !!p)
+				.join(' ')
+				.toLowerCase()
+				.trim();
+			const newFullName = [newUser.firstName, newUser.lastName]
+				.filter((p): p is string => !!p)
+				.join(' ')
+				.toLowerCase()
+				.trim();
+
+			const commands: Array<[string, ...any[]]> = [];
+
+			if (oldUsername && oldUsername !== newUsername) {
+				commands.push(['hdel', this.USERNAME_INDEX_KEY, oldUsername]);
+			}
+			if (oldFirstName && oldFirstName !== newFirstName) {
+				commands.push(['zrem', `${this.NAME_INDEX_KEY}:${oldFirstName}`, oldUser.id]);
+			}
+			if (oldLastName && oldLastName !== newLastName) {
+				commands.push(['zrem', `${this.NAME_INDEX_KEY}:${oldLastName}`, oldUser.id]);
+			}
+			if (oldFullName && oldFullName !== newFullName) {
+				commands.push(['zrem', `${this.NAME_INDEX_KEY}:${oldFullName}`, oldUser.id]);
+			}
+
+			if (commands.length === 0) {
+				return;
+			}
+
+			await this.cacheService.pipeline(commands);
+			this.logger.debug(`Removed stale index keys for user ${oldUser.id}`);
+		} catch (error) {
+			this.logger.error(`Failed to remove stale index keys for user ${oldUser.id}:`, error);
 			throw error;
 		}
 	}

--- a/src/modules/profile/services/profile.service.spec.ts
+++ b/src/modules/profile/services/profile.service.spec.ts
@@ -36,7 +36,11 @@ describe('ProfileService', () => {
 	let service: ProfileService;
 	let userRepository: jest.Mocked<UserRepository>;
 	let mediaClient: jest.Mocked<MediaClientService>;
-	let searchIndexService: { indexUser: jest.Mock; removeUserFromIndex: jest.Mock };
+	let searchIndexService: {
+		indexUser: jest.Mock;
+		removeUserFromIndex: jest.Mock;
+		removeStaleIndexKeys: jest.Mock;
+	};
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
@@ -61,6 +65,7 @@ describe('ProfileService', () => {
 					useValue: {
 						indexUser: jest.fn().mockResolvedValue(undefined),
 						removeUserFromIndex: jest.fn().mockResolvedValue(undefined),
+						removeStaleIndexKeys: jest.fn().mockResolvedValue(undefined),
 					},
 				},
 			],
@@ -149,7 +154,7 @@ describe('ProfileService', () => {
 			expect(searchIndexService.indexUser).toHaveBeenCalledWith(saved);
 		});
 
-		it('removes old index entries when username changes', async () => {
+		it('removes only stale index keys when username changes', async () => {
 			const user = { ...mockUser(), username: 'old-name' } as User;
 			const dto: UpdateProfileDto = { username: 'new-name' };
 			const saved = { ...user, username: 'new-name' } as User;
@@ -160,9 +165,40 @@ describe('ProfileService', () => {
 
 			await service.updateProfile('uuid-1', dto);
 
-			expect(searchIndexService.removeUserFromIndex).toHaveBeenCalledWith(
-				expect.objectContaining({ username: 'old-name' })
+			expect(searchIndexService.removeUserFromIndex).not.toHaveBeenCalled();
+			expect(searchIndexService.removeStaleIndexKeys).toHaveBeenCalledWith(
+				expect.objectContaining({ username: 'old-name' }),
+				expect.objectContaining({ username: 'new-name' })
 			);
+		});
+
+		it('passes a lean UserIndexSnapshot (no relations or extra fields) as the old snapshot', async () => {
+			const user = {
+				...mockUser(),
+				username: 'old-name',
+				privacySettings: { showLastSeen: true } as any,
+				biography: 'secret bio',
+			} as User;
+			const dto: UpdateProfileDto = { username: 'new-name' };
+			const saved = { ...user, username: 'new-name' } as User;
+
+			userRepository.findById.mockResolvedValue(user);
+			userRepository.findByUsernameInsensitive.mockResolvedValue(null);
+			userRepository.save.mockResolvedValue(saved);
+
+			await service.updateProfile('uuid-1', dto);
+
+			const [oldSnapshot] = searchIndexService.removeStaleIndexKeys.mock.calls[0];
+			expect(Object.keys(oldSnapshot).sort()).toEqual([
+				'createdAt',
+				'firstName',
+				'id',
+				'lastName',
+				'phoneNumber',
+				'username',
+			]);
+			expect(oldSnapshot).not.toHaveProperty('privacySettings');
+			expect(oldSnapshot).not.toHaveProperty('biography');
 		});
 
 		it('swallows search indexing errors without failing the update', async () => {

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -9,7 +9,7 @@ import { User } from '../../common/entities/user.entity';
 import { UserRepository } from '../../common/repositories';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
 import { MediaClientService } from './media-client.service';
-import { SearchIndexService } from '../../cache/search-index.service';
+import { SearchIndexService, UserIndexSnapshot } from '../../cache/search-index.service';
 
 @Injectable()
 export class ProfileService {
@@ -37,7 +37,16 @@ export class ProfileService {
 
 	public async updateProfile(id: string, dto: UpdateProfileDto, authorization?: string): Promise<User> {
 		const user = await this.findOne(id);
-		const previousSnapshot = { ...user };
+		// On ne capture que les champs utiles à l'indexation de recherche pour
+		// éviter de copier l'entité complète (relations, colonnes internes).
+		const previousSnapshot: UserIndexSnapshot = {
+			id: user.id,
+			phoneNumber: user.phoneNumber,
+			username: user.username,
+			firstName: user.firstName,
+			lastName: user.lastName,
+			createdAt: user.createdAt,
+		};
 
 		if (dto.username && dto.username !== user.username) {
 			const existing = await this.userRepository.findByUsernameInsensitive(dto.username, true);
@@ -72,10 +81,11 @@ export class ProfileService {
 			saved.lastName !== previousSnapshot.lastName
 		) {
 			try {
-				// Index new data first, then remove old entries — if indexUser fails,
-				// the user remains discoverable under the old keys instead of vanishing.
+				// On indexe d'abord la nouvelle donnée puis on retire les seules
+				// clés devenues obsolètes. Si `indexUser` échoue, l'utilisateur
+				// reste trouvable sous ses anciennes clés au lieu de disparaître.
 				await this.searchIndexService.indexUser(saved);
-				await this.searchIndexService.removeUserFromIndex(previousSnapshot as User);
+				await this.searchIndexService.removeStaleIndexKeys(previousSnapshot, saved);
 			} catch (err) {
 				this.logger.warn(`Failed to update search index for user ${saved.id}: ${err}`);
 			}


### PR DESCRIPTION
## Contexte

Deux remarques Copilot non corrigées lors de la PR #87 (WHISPR-825) nécessitent un refactoring dédié de `SearchIndexService` :

1. **`removeUserFromIndex` supprime trop de clés** — lors d'un `updateProfile`, on appelle `removeUserFromIndex(previousSnapshot)` pour retirer les anciennes entrées. Mais cette méthode touche aussi `search:phone` et `user:cache:<id>`, ce qui est inutile : le numéro de téléphone ne change pas lors d'une mise à jour de profil, et `indexUser(saved)` réécrit déjà le cache avec la nouvelle version juste avant.
2. **`previousSnapshot = { ...user }` copie toute l'entité** — le spread embarque les relations (`privacySettings`) et les colonnes non pertinentes (`biography`, `profilePictureUrl`, `lastSeen`, etc.) alors que la logique de nettoyage n'a besoin que d'un petit sous-ensemble.

## Changements

### `src/modules/cache/search-index.service.ts`

- Nouveau type exporté `UserIndexSnapshot = Pick<User, 'id' | 'phoneNumber' | 'username' | 'firstName' | 'lastName' | 'createdAt'>`.
- Nouvelle méthode `removeStaleIndexKeys(oldUser, newUser)` qui ne supprime que les entrées dont la valeur normalisée a réellement changé :
  - `search:username:<ancien>` si le username change ;
  - `search:name:<ancien prénom>` si le prénom change ;
  - `search:name:<ancien nom>` si le nom change ;
  - `search:name:<ancien prénom nom>` si l'un des deux change.
  Aucune opération si rien n'a bougé (`cacheService.pipeline` n'est pas appelé du tout).
- `search:phone` et `user:cache:<id>` ne sont **jamais** touchés par cette méthode.

### `src/modules/profile/services/profile.service.ts`

- `previousSnapshot` est désormais construit explicitement comme un `UserIndexSnapshot` (6 champs), plus de spread de l'entité complète.
- L'appel à `removeUserFromIndex(previousSnapshot as User)` est remplacé par `removeStaleIndexKeys(previousSnapshot, saved)`.
- L'ordre "indexer d'abord, retirer l'ancien ensuite" est conservé — si `indexUser` échoue, l'utilisateur reste trouvable sous ses anciennes clés.

### Tests

- 6 nouveaux tests pour `removeStaleIndexKeys` : no-op si rien ne change, retrait ciblé par champ (username / firstName / lastName), aucune atteinte au hash phone ni au cache, égalité insensible à la casse, propagation d'erreur pipeline.
- Spec `ProfileService` mise à jour : l'assertion cible maintenant `removeStaleIndexKeys` et vérifie que `removeUserFromIndex` n'est plus appelée. Un test dédié garantit que le snapshot transmis contient strictement les 6 champs du type (pas de `privacySettings`, pas de `biography`).

## Plan de test

- [x] `npx jest search-index.service.spec profile.service.spec` — 37 tests verts
- [x] `npx jest` suite complète — 69 suites / 633 tests verts
- [x] Prettier + ESLint sur les fichiers touchés — clean
- [x] Pre-push hook complet (unit + e2e Docker) — vert

Closes WHISPR-832