### PR TITLE
feat(appeals): support blocked_image appeal type with redis event

### DIFF
--- a/src/database/migrations/1776000700000-AppealTypeAndNullableSanction.ts
+++ b/src/database/migrations/1776000700000-AppealTypeAndNullableSanction.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AppealTypeAndNullableSanction1776000700000 implements MigrationInterface {
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		// Make sanction_id nullable so blocked_image appeals can skip it
+		await queryRunner.query(`ALTER TABLE users.appeals ALTER COLUMN sanction_id DROP NOT NULL`);
+
+		// Add type column (sanction | blocked_image), default to sanction for backward compat
+		await queryRunner.query(
+			`ALTER TABLE users.appeals ADD COLUMN IF NOT EXISTS type VARCHAR(30) NOT NULL DEFAULT 'sanction' CHECK (type IN ('sanction', 'blocked_image'))`
+		);
+
+		// Index to speed up admin queue queries filtered by type + status
+		await queryRunner.query(
+			`CREATE INDEX IF NOT EXISTS idx_appeals_type_status ON users.appeals(type, status)`
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP INDEX IF EXISTS users.idx_appeals_type_status`);
+		await queryRunner.query(`ALTER TABLE users.appeals DROP COLUMN IF EXISTS type`);
+		// Note: cannot safely restore NOT NULL on sanction_id because blocked_image
+		// rows may have null sanction_id. Leave the column nullable on rollback.
+	}
+}

--- a/src/modules/appeals/dto/create-appeal.dto.spec.ts
+++ b/src/modules/appeals/dto/create-appeal.dto.spec.ts
@@ -1,0 +1,166 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateAppealDto, AppealTypeEnum } from './create-appeal.dto';
+
+describe('CreateAppealDto', () => {
+	const validUuid = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+	async function validateDto(payload: Record<string, unknown>) {
+		const dto = plainToInstance(CreateAppealDto, payload);
+		return validate(dto);
+	}
+
+	describe('sanction appeals', () => {
+		it('passes validation with a valid sanctionId and no evidence', async () => {
+			const errors = await validateDto({
+				sanctionId: validUuid,
+				reason: 'I disagree',
+			});
+			expect(errors).toHaveLength(0);
+		});
+
+		it('fails when sanctionId is missing for sanction type', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.SANCTION,
+				reason: 'no id',
+			});
+			expect(errors.length).toBeGreaterThan(0);
+			expect(errors.some((e) => e.property === 'sanctionId')).toBe(true);
+		});
+
+		it('fails when sanctionId is not a UUID for sanction type', async () => {
+			const errors = await validateDto({
+				sanctionId: 'not-a-uuid',
+				reason: 'bad id',
+			});
+			expect(errors.some((e) => e.property === 'sanctionId')).toBe(true);
+		});
+	});
+
+	describe('blocked_image appeals — custom evidence validator', () => {
+		const validEvidence = {
+			thumbnailBase64: 'abc',
+			conversationId: 'conv-1',
+			messageTempId: 'tmp-1',
+		};
+
+		it('passes with complete evidence', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'false positive',
+				evidence: validEvidence,
+			});
+			expect(errors).toHaveLength(0);
+		});
+
+		it('does not require sanctionId when type is blocked_image', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'ok',
+				evidence: validEvidence,
+			});
+			expect(errors.some((e) => e.property === 'sanctionId')).toBe(false);
+		});
+
+		it('fails when evidence is missing', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'missing',
+			});
+			expect(errors.some((e) => e.property === 'evidence')).toBe(true);
+		});
+
+		it('fails when evidence is not an object', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'bad',
+				evidence: 'not-an-object',
+			});
+			expect(errors.some((e) => e.property === 'evidence')).toBe(true);
+		});
+
+		it('fails when thumbnailBase64 is missing', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'x',
+				evidence: { conversationId: 'c', messageTempId: 'm' },
+			});
+			expect(errors.some((e) => e.property === 'evidence')).toBe(true);
+		});
+
+		it('fails when thumbnailBase64 is empty', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'x',
+				evidence: { ...validEvidence, thumbnailBase64: '' },
+			});
+			expect(errors.some((e) => e.property === 'evidence')).toBe(true);
+		});
+
+		it('fails when thumbnailBase64 exceeds 100KB', async () => {
+			const huge = 'a'.repeat(100 * 1024 + 1);
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'x',
+				evidence: { ...validEvidence, thumbnailBase64: huge },
+			});
+			expect(errors.some((e) => e.property === 'evidence')).toBe(true);
+		});
+
+		it('fails when conversationId is missing', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'x',
+				evidence: { thumbnailBase64: 'd', messageTempId: 'm' },
+			});
+			expect(errors.some((e) => e.property === 'evidence')).toBe(true);
+		});
+
+		it('fails when conversationId is empty', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'x',
+				evidence: { ...validEvidence, conversationId: '' },
+			});
+			expect(errors.some((e) => e.property === 'evidence')).toBe(true);
+		});
+
+		it('fails when messageTempId is missing', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'x',
+				evidence: { thumbnailBase64: 'd', conversationId: 'c' },
+			});
+			expect(errors.some((e) => e.property === 'evidence')).toBe(true);
+		});
+
+		it('fails when messageTempId is empty', async () => {
+			const errors = await validateDto({
+				type: AppealTypeEnum.BLOCKED_IMAGE,
+				reason: 'x',
+				evidence: { ...validEvidence, messageTempId: '' },
+			});
+			expect(errors.some((e) => e.property === 'evidence')).toBe(true);
+		});
+	});
+
+	describe('custom validator — non blocked_image', () => {
+		it('accepts any object evidence when type is sanction', async () => {
+			const errors = await validateDto({
+				sanctionId: validUuid,
+				reason: 'ok',
+				evidence: { anything: 'goes' },
+			});
+			expect(errors).toHaveLength(0);
+		});
+
+		it('rejects non-object evidence on sanction appeals via @IsObject', async () => {
+			const errors = await validateDto({
+				sanctionId: validUuid,
+				reason: 'ok',
+				evidence: 'string-value',
+			});
+			expect(errors.some((e) => e.property === 'evidence')).toBe(true);
+		});
+	});
+});

--- a/src/modules/appeals/dto/create-appeal.dto.ts
+++ b/src/modules/appeals/dto/create-appeal.dto.ts
@@ -1,17 +1,83 @@
-import { IsUUID, IsString, IsOptional, IsObject } from 'class-validator';
+import {
+	IsUUID,
+	IsString,
+	IsOptional,
+	IsObject,
+	IsEnum,
+	ValidateIf,
+	registerDecorator,
+	ValidationOptions,
+	ValidationArguments,
+} from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+export enum AppealTypeEnum {
+	SANCTION = 'sanction',
+	BLOCKED_IMAGE = 'blocked_image',
+}
+
+// Max size for base64-encoded thumbnail: ~100KB (base64 overhead ~33% → ~75KB raw)
+const MAX_THUMBNAIL_BASE64_LENGTH = 100 * 1024;
+
+function IsBlockedImageEvidence(validationOptions?: ValidationOptions) {
+	return function (object: object, propertyName: string) {
+		registerDecorator({
+			name: 'isBlockedImageEvidence',
+			target: object.constructor,
+			propertyName,
+			options: validationOptions,
+			validator: {
+				validate(value: unknown, args: ValidationArguments) {
+					const obj = args.object as CreateAppealDto;
+					if (obj.type !== AppealTypeEnum.BLOCKED_IMAGE) {
+						return true;
+					}
+					if (!value || typeof value !== 'object') return false;
+					const ev = value as Record<string, unknown>;
+					if (typeof ev.thumbnailBase64 !== 'string' || ev.thumbnailBase64.length === 0) {
+						return false;
+					}
+					if (ev.thumbnailBase64.length > MAX_THUMBNAIL_BASE64_LENGTH) {
+						return false;
+					}
+					if (typeof ev.conversationId !== 'string' || ev.conversationId.length === 0) {
+						return false;
+					}
+					if (typeof ev.messageTempId !== 'string' || ev.messageTempId.length === 0) {
+						return false;
+					}
+					return true;
+				},
+				defaultMessage(): string {
+					return `evidence for blocked_image appeals must include thumbnailBase64 (<=${MAX_THUMBNAIL_BASE64_LENGTH} chars), conversationId and messageTempId`;
+				},
+			},
+		});
+	};
+}
+
 export class CreateAppealDto {
-	@ApiProperty({ description: 'Sanction to appeal' })
+	@ApiPropertyOptional({ description: 'Sanction to appeal (required when type=sanction)' })
+	@ValidateIf((o: CreateAppealDto) => o.type !== AppealTypeEnum.BLOCKED_IMAGE)
 	@IsUUID()
-	sanctionId: string;
+	sanctionId?: string;
+
+	@ApiPropertyOptional({
+		enum: AppealTypeEnum,
+		description: 'Appeal type',
+		default: AppealTypeEnum.SANCTION,
+	})
+	@IsOptional()
+	@IsEnum(AppealTypeEnum)
+	type?: AppealTypeEnum = AppealTypeEnum.SANCTION;
 
 	@ApiProperty({ description: 'Reason for the appeal' })
 	@IsString()
 	reason: string;
 
 	@ApiPropertyOptional({ description: 'Supporting evidence' })
-	@IsOptional()
+	@ValidateIf((o: CreateAppealDto) => o.type === AppealTypeEnum.BLOCKED_IMAGE || o.evidence !== undefined)
 	@IsObject()
+	@IsBlockedImageEvidence()
 	evidence?: Record<string, any>;
 }

--- a/src/modules/appeals/dto/query-appeals.dto.ts
+++ b/src/modules/appeals/dto/query-appeals.dto.ts
@@ -8,6 +8,11 @@ export enum AppealStatus {
 	REJECTED = 'rejected',
 }
 
+export enum AppealTypeFilter {
+	SANCTION = 'sanction',
+	BLOCKED_IMAGE = 'blocked_image',
+}
+
 export class QueryAppealsDto {
 	@ApiPropertyOptional({ enum: AppealStatus, description: 'Filter by appeal status' })
 	@IsOptional()
@@ -23,6 +28,11 @@ export class QueryAppealsDto {
 	@IsOptional()
 	@IsUUID()
 	sanctionId?: string;
+
+	@ApiPropertyOptional({ enum: AppealTypeFilter, description: 'Filter by appeal type' })
+	@IsOptional()
+	@IsEnum(AppealTypeFilter)
+	type?: AppealTypeFilter;
 
 	@ApiPropertyOptional({ description: 'Start date (ISO 8601)' })
 	@IsOptional()

--- a/src/modules/appeals/entities/appeal.entity.ts
+++ b/src/modules/appeals/entities/appeal.entity.ts
@@ -10,6 +10,8 @@ import {
 import { User } from '../../common/entities/user.entity';
 import { UserSanction } from '../../sanctions/entities/user-sanction.entity';
 
+export type AppealType = 'sanction' | 'blocked_image';
+
 @Entity({ name: 'appeals', schema: 'users' })
 export class Appeal {
 	@PrimaryGeneratedColumn('uuid')
@@ -22,12 +24,15 @@ export class Appeal {
 	@Column({ name: 'user_id', type: 'uuid' })
 	userId: string;
 
-	@ManyToOne(() => UserSanction, { onDelete: 'CASCADE' })
+	@ManyToOne(() => UserSanction, { onDelete: 'CASCADE', nullable: true })
 	@JoinColumn({ name: 'sanction_id' })
-	sanction: UserSanction;
+	sanction: UserSanction | null;
 
-	@Column({ name: 'sanction_id', type: 'uuid' })
-	sanctionId: string;
+	@Column({ name: 'sanction_id', type: 'uuid', nullable: true })
+	sanctionId: string | null;
+
+	@Column({ type: 'varchar', length: 30, default: 'sanction' })
+	type: AppealType;
 
 	@Column({ type: 'text' })
 	reason: string;

--- a/src/modules/appeals/repositories/appeals.repository.ts
+++ b/src/modules/appeals/repositories/appeals.repository.ts
@@ -23,9 +23,13 @@ export class AppealsRepository {
 		return this.repo.find({ where: { userId }, order: { createdAt: 'DESC' } });
 	}
 
-	async findPendingQueue(limit: number = 50, offset: number = 0): Promise<Appeal[]> {
+	async findPendingQueue(
+		limit: number = 50,
+		offset: number = 0,
+		type?: 'sanction' | 'blocked_image'
+	): Promise<Appeal[]> {
 		return this.repo.find({
-			where: { status: 'pending' },
+			where: type ? { status: 'pending', type } : { status: 'pending' },
 			order: { createdAt: 'ASC' },
 			take: limit,
 			skip: offset,
@@ -40,6 +44,7 @@ export class AppealsRepository {
 		status?: string;
 		userId?: string;
 		sanctionId?: string;
+		type?: string;
 		dateFrom?: Date;
 		dateTo?: Date;
 		limit: number;
@@ -55,6 +60,9 @@ export class AppealsRepository {
 		}
 		if (filters.sanctionId) {
 			qb.andWhere('a.sanctionId = :sanctionId', { sanctionId: filters.sanctionId });
+		}
+		if (filters.type) {
+			qb.andWhere('a.type = :type', { type: filters.type });
 		}
 		if (filters.dateFrom) {
 			qb.andWhere('a.createdAt >= :dateFrom', { dateFrom: filters.dateFrom });

--- a/src/modules/appeals/services/appeals-extended.service.spec.ts
+++ b/src/modules/appeals/services/appeals-extended.service.spec.ts
@@ -4,6 +4,7 @@ import { AppealsService } from './appeals.service';
 import { AppealsRepository } from '../repositories/appeals.repository';
 import { RolesService } from '../../roles/services/roles.service';
 import { SanctionsService } from '../../sanctions/services/sanctions.service';
+import { RedisConfig } from '../../../config/redis.config';
 import { Appeal } from '../entities/appeal.entity';
 
 describe('AppealsService — extended features', () => {
@@ -17,6 +18,7 @@ describe('AppealsService — extended features', () => {
 		user: {} as any,
 		sanctionId: 'sanction-1',
 		sanction: {} as any,
+		type: 'sanction',
 		reason: 'I disagree',
 		evidence: {},
 		status: 'pending',
@@ -56,6 +58,14 @@ describe('AppealsService — extended features', () => {
 					useValue: {
 						getSanction: jest.fn(),
 						liftSanction: jest.fn(),
+					},
+				},
+				{
+					provide: RedisConfig,
+					useValue: {
+						getClient: jest.fn().mockReturnValue({
+							publish: jest.fn().mockResolvedValue(1),
+						}),
 					},
 				},
 			],

--- a/src/modules/appeals/services/appeals.service.spec.ts
+++ b/src/modules/appeals/services/appeals.service.spec.ts
@@ -196,6 +196,17 @@ describe('AppealsService', () => {
 
 			await expect(service.getAppealQueue('user-1')).rejects.toThrow(ForbiddenException);
 		});
+
+		it('should filter pending queue by type when provided', async () => {
+			rolesService.ensureAdminOrModerator.mockResolvedValue(undefined);
+			const queue = [mockAppeal({ type: 'blocked_image', sanctionId: null })];
+			appealsRepository.findPendingQueue.mockResolvedValue(queue);
+
+			const result = await service.getAppealQueue('admin-1', 10, 5, 'blocked_image');
+
+			expect(appealsRepository.findPendingQueue).toHaveBeenCalledWith(10, 5, 'blocked_image');
+			expect(result).toEqual(queue);
+		});
 	});
 
 	describe('getAppeal', () => {
@@ -280,6 +291,37 @@ describe('AppealsService', () => {
 	});
 
 	describe('createAppeal — blocked_image', () => {
+		it('throws BadRequestException when sanction appeal has no sanctionId', async () => {
+			await expect(
+				service.createAppeal({ reason: 'no sanction id', type: 'sanction' as any } as any, 'user-1')
+			).rejects.toThrow(BadRequestException);
+			expect(sanctionsService.getSanction).not.toHaveBeenCalled();
+		});
+
+		it('throws BadRequestException when user already has 3 active appeals (blocked_image)', async () => {
+			appealsRepository.findByUserId.mockResolvedValue([
+				mockAppeal({ id: 'a1', status: 'pending' }),
+				mockAppeal({ id: 'a2', status: 'under_review' }),
+				mockAppeal({ id: 'a3', status: 'pending' }),
+			]);
+
+			await expect(
+				service.createAppeal(
+					{
+						type: 'blocked_image' as any,
+						reason: 'false positive',
+						evidence: {
+							thumbnailBase64: 'data',
+							conversationId: 'conv-1',
+							messageTempId: 'tmp-1',
+						},
+					} as any,
+					'user-1'
+				)
+			).rejects.toThrow(BadRequestException);
+			expect(appealsRepository.create).not.toHaveBeenCalled();
+		});
+
 		it('creates a blocked_image appeal without a sanctionId', async () => {
 			appealsRepository.findByUserId.mockResolvedValue([]);
 			const created = mockAppeal({
@@ -356,6 +398,57 @@ describe('AppealsService', () => {
 				messageTempId: 'tmp-1',
 				reviewerNotes: 'looks fine',
 			});
+		});
+
+		it('does not throw when redis publish fails (swallows error and logs)', async () => {
+			rolesService.ensureAdminOrModerator.mockResolvedValue(undefined);
+			const appeal = mockAppeal({
+				type: 'blocked_image',
+				sanctionId: null,
+				status: 'pending',
+				evidence: { conversationId: 'conv-1', messageTempId: 'tmp-1' },
+			});
+			appealsRepository.findById.mockResolvedValue(appeal);
+			const updated = mockAppeal({
+				type: 'blocked_image',
+				sanctionId: null,
+				status: 'accepted',
+				reviewerId: 'admin-1',
+				evidence: { conversationId: 'conv-1', messageTempId: 'tmp-1' },
+			});
+			appealsRepository.update.mockResolvedValue(updated);
+			redisPublish.mockRejectedValueOnce(new Error('redis down'));
+
+			await expect(
+				service.reviewAppeal('appeal-1', 'admin-1', { status: 'accepted' as any })
+			).resolves.toBeDefined();
+			expect(sanctionsService.liftSanction).not.toHaveBeenCalled();
+		});
+
+		it('publishes with null ids when evidence has no conversationId/messageTempId', async () => {
+			rolesService.ensureAdminOrModerator.mockResolvedValue(undefined);
+			const appeal = mockAppeal({
+				type: 'blocked_image',
+				sanctionId: null,
+				status: 'pending',
+				evidence: {},
+			});
+			appealsRepository.findById.mockResolvedValue(appeal);
+			const updated = mockAppeal({
+				type: 'blocked_image',
+				sanctionId: null,
+				status: 'accepted',
+				reviewerId: 'admin-1',
+				evidence: {},
+			});
+			appealsRepository.update.mockResolvedValue(updated);
+
+			await service.reviewAppeal('appeal-1', 'admin-1', { status: 'accepted' as any });
+
+			const [, rawPayload] = redisPublish.mock.calls[0];
+			expect(JSON.parse(rawPayload)).toEqual(
+				expect.objectContaining({ conversationId: null, messageTempId: null })
+			);
 		});
 
 		it('publishes rejected event when rejected', async () => {

--- a/src/modules/appeals/services/appeals.service.spec.ts
+++ b/src/modules/appeals/services/appeals.service.spec.ts
@@ -9,6 +9,7 @@ import { AppealsService } from './appeals.service';
 import { AppealsRepository } from '../repositories/appeals.repository';
 import { RolesService } from '../../roles/services/roles.service';
 import { SanctionsService } from '../../sanctions/services/sanctions.service';
+import { RedisConfig } from '../../../config/redis.config';
 import { Appeal } from '../entities/appeal.entity';
 import { UserSanction } from '../../sanctions/entities/user-sanction.entity';
 
@@ -17,6 +18,7 @@ describe('AppealsService', () => {
 	let appealsRepository: jest.Mocked<AppealsRepository>;
 	let rolesService: jest.Mocked<RolesService>;
 	let sanctionsService: jest.Mocked<SanctionsService>;
+	let redisPublish: jest.Mock;
 
 	const mockSanction = (overrides: Partial<UserSanction> = {}): UserSanction => ({
 		id: 'sanction-1',
@@ -39,6 +41,7 @@ describe('AppealsService', () => {
 		user: {} as any,
 		sanctionId: 'sanction-1',
 		sanction: {} as any,
+		type: 'sanction',
 		reason: 'I did not do it',
 		evidence: {},
 		status: 'pending',
@@ -75,6 +78,14 @@ describe('AppealsService', () => {
 					useValue: {
 						getSanction: jest.fn(),
 						liftSanction: jest.fn(),
+					},
+				},
+				{
+					provide: RedisConfig,
+					useValue: {
+						getClient: jest.fn().mockReturnValue({
+							publish: (redisPublish = jest.fn().mockResolvedValue(1)),
+						}),
 					},
 				},
 			],
@@ -265,6 +276,113 @@ describe('AppealsService', () => {
 			await expect(
 				service.reviewAppeal('appeal-1', 'admin-1', { status: 'rejected' as any })
 			).resolves.toBeDefined();
+		});
+	});
+
+	describe('createAppeal — blocked_image', () => {
+		it('creates a blocked_image appeal without a sanctionId', async () => {
+			appealsRepository.findByUserId.mockResolvedValue([]);
+			const created = mockAppeal({
+				type: 'blocked_image',
+				sanctionId: null,
+				evidence: {
+					thumbnailBase64: 'data',
+					conversationId: 'conv-1',
+					messageTempId: 'tmp-1',
+				},
+			});
+			appealsRepository.create.mockResolvedValue(created);
+
+			const result = await service.createAppeal(
+				{
+					type: 'blocked_image' as any,
+					reason: 'false positive',
+					evidence: {
+						thumbnailBase64: 'data',
+						conversationId: 'conv-1',
+						messageTempId: 'tmp-1',
+					},
+				} as any,
+				'user-1'
+			);
+
+			// Must not fetch a sanction
+			expect(sanctionsService.getSanction).not.toHaveBeenCalled();
+			expect(appealsRepository.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					userId: 'user-1',
+					sanctionId: null,
+					type: 'blocked_image',
+					status: 'pending',
+				})
+			);
+			expect(result).toBe(created);
+		});
+	});
+
+	describe('reviewAppeal — blocked_image', () => {
+		it('publishes approved event and does NOT call liftSanction when accepted', async () => {
+			rolesService.ensureAdminOrModerator.mockResolvedValue(undefined);
+			const appeal = mockAppeal({
+				type: 'blocked_image',
+				sanctionId: null,
+				status: 'pending',
+				evidence: { conversationId: 'conv-1', messageTempId: 'tmp-1' },
+			});
+			appealsRepository.findById.mockResolvedValue(appeal);
+			const updated = mockAppeal({
+				type: 'blocked_image',
+				sanctionId: null,
+				status: 'accepted',
+				reviewerId: 'admin-1',
+				reviewerNotes: 'looks fine',
+				evidence: { conversationId: 'conv-1', messageTempId: 'tmp-1' },
+			});
+			appealsRepository.update.mockResolvedValue(updated);
+
+			await service.reviewAppeal('appeal-1', 'admin-1', {
+				status: 'accepted' as any,
+				reviewerNotes: 'looks fine',
+			});
+
+			expect(sanctionsService.liftSanction).not.toHaveBeenCalled();
+			expect(redisPublish).toHaveBeenCalledTimes(1);
+			const [channel, rawPayload] = redisPublish.mock.calls[0];
+			expect(channel).toBe('whispr:moderation:blocked_image_approved');
+			expect(JSON.parse(rawPayload)).toEqual({
+				appealId: 'appeal-1',
+				userId: 'user-1',
+				conversationId: 'conv-1',
+				messageTempId: 'tmp-1',
+				reviewerNotes: 'looks fine',
+			});
+		});
+
+		it('publishes rejected event when rejected', async () => {
+			rolesService.ensureAdminOrModerator.mockResolvedValue(undefined);
+			const appeal = mockAppeal({
+				type: 'blocked_image',
+				sanctionId: null,
+				status: 'pending',
+				evidence: { conversationId: 'conv-1', messageTempId: 'tmp-1' },
+			});
+			appealsRepository.findById.mockResolvedValue(appeal);
+			const updated = mockAppeal({
+				type: 'blocked_image',
+				sanctionId: null,
+				status: 'rejected',
+				reviewerId: 'admin-1',
+				evidence: { conversationId: 'conv-1', messageTempId: 'tmp-1' },
+			});
+			appealsRepository.update.mockResolvedValue(updated);
+
+			await service.reviewAppeal('appeal-1', 'admin-1', { status: 'rejected' as any });
+
+			expect(sanctionsService.liftSanction).not.toHaveBeenCalled();
+			expect(redisPublish).toHaveBeenCalledWith(
+				'whispr:moderation:blocked_image_rejected',
+				expect.any(String)
+			);
 		});
 	});
 });

--- a/src/modules/appeals/services/appeals.service.ts
+++ b/src/modules/appeals/services/appeals.service.ts
@@ -1,20 +1,60 @@
-import { Injectable, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import {
+	Injectable,
+	Logger,
+	NotFoundException,
+	ConflictException,
+	BadRequestException,
+} from '@nestjs/common';
 import { AppealsRepository } from '../repositories/appeals.repository';
 import { RolesService } from '../../roles/services/roles.service';
 import { SanctionsService } from '../../sanctions/services/sanctions.service';
-import { CreateAppealDto } from '../dto/create-appeal.dto';
+import { RedisConfig } from '../../../config/redis.config';
+import { CreateAppealDto, AppealTypeEnum } from '../dto/create-appeal.dto';
 import { ReviewAppealDto } from '../dto/review-appeal.dto';
 import { Appeal } from '../entities/appeal.entity';
 
+const BLOCKED_IMAGE_APPROVED_CHANNEL = 'whispr:moderation:blocked_image_approved';
+const BLOCKED_IMAGE_REJECTED_CHANNEL = 'whispr:moderation:blocked_image_rejected';
+
 @Injectable()
 export class AppealsService {
+	private readonly logger = new Logger(AppealsService.name);
+
 	constructor(
 		private readonly appealsRepository: AppealsRepository,
 		private readonly rolesService: RolesService,
-		private readonly sanctionsService: SanctionsService
+		private readonly sanctionsService: SanctionsService,
+		private readonly redisConfig: RedisConfig
 	) {}
 
 	async createAppeal(dto: CreateAppealDto, userId: string): Promise<Appeal> {
+		const type = dto.type ?? AppealTypeEnum.SANCTION;
+
+		if (type === AppealTypeEnum.BLOCKED_IMAGE) {
+			// Enforce active-appeal cap across all types
+			const userAppeals = await this.appealsRepository.findByUserId(userId);
+			const activeAppeals = userAppeals.filter(
+				(a) => a.status === 'pending' || a.status === 'under_review'
+			);
+			if (activeAppeals.length >= 3) {
+				throw new BadRequestException('Maximum of 3 active appeals reached');
+			}
+
+			return this.appealsRepository.create({
+				userId,
+				sanctionId: null,
+				type: 'blocked_image',
+				reason: dto.reason,
+				evidence: dto.evidence || {},
+				status: 'pending',
+			});
+		}
+
+		// Default: sanction appeal (legacy behaviour)
+		if (!dto.sanctionId) {
+			throw new BadRequestException('sanctionId is required for sanction appeals');
+		}
+
 		const sanction = await this.sanctionsService.getSanction(dto.sanctionId);
 		if (!sanction.active) {
 			throw new ConflictException('Sanction is no longer active');
@@ -39,6 +79,7 @@ export class AppealsService {
 		return this.appealsRepository.create({
 			userId,
 			sanctionId: dto.sanctionId,
+			type: 'sanction',
 			reason: dto.reason,
 			evidence: dto.evidence || {},
 			status: 'pending',
@@ -49,8 +90,16 @@ export class AppealsService {
 		return this.appealsRepository.findByUserId(userId);
 	}
 
-	async getAppealQueue(adminId: string, limit: number = 50, offset: number = 0): Promise<Appeal[]> {
+	async getAppealQueue(
+		adminId: string,
+		limit: number = 50,
+		offset: number = 0,
+		type?: 'sanction' | 'blocked_image'
+	): Promise<Appeal[]> {
 		await this.rolesService.ensureAdminOrModerator(adminId);
+		if (type) {
+			return this.appealsRepository.findPendingQueue(limit, offset, type);
+		}
 		return this.appealsRepository.findPendingQueue(limit, offset);
 	}
 
@@ -77,11 +126,35 @@ export class AppealsService {
 
 		const updated = await this.appealsRepository.update(appeal);
 
-		if (dto.status === 'accepted') {
-			await this.sanctionsService.liftSanction(appeal.sanctionId, adminId);
+		if (updated.type === 'blocked_image') {
+			await this.publishBlockedImageDecision(updated);
+		} else if (dto.status === 'accepted' && updated.sanctionId) {
+			await this.sanctionsService.liftSanction(updated.sanctionId, adminId);
 		}
 
 		return updated;
+	}
+
+	private async publishBlockedImageDecision(appeal: Appeal): Promise<void> {
+		const channel =
+			appeal.status === 'accepted' ? BLOCKED_IMAGE_APPROVED_CHANNEL : BLOCKED_IMAGE_REJECTED_CHANNEL;
+
+		const payload = {
+			appealId: appeal.id,
+			userId: appeal.userId,
+			conversationId: (appeal.evidence?.conversationId as string | undefined) ?? null,
+			messageTempId: (appeal.evidence?.messageTempId as string | undefined) ?? null,
+			reviewerNotes: appeal.reviewerNotes,
+		};
+
+		try {
+			await this.redisConfig.getClient().publish(channel, JSON.stringify(payload));
+		} catch (err) {
+			this.logger.error(
+				`Failed to publish blocked_image decision on ${channel} for appeal ${appeal.id}`,
+				err instanceof Error ? err.stack : err
+			);
+		}
 	}
 
 	async findFiltered(
@@ -90,6 +163,7 @@ export class AppealsService {
 			status?: string;
 			userId?: string;
 			sanctionId?: string;
+			type?: string;
 			dateFrom?: string;
 			dateTo?: string;
 			limit?: string;
@@ -101,6 +175,7 @@ export class AppealsService {
 			status: filters.status,
 			userId: filters.userId,
 			sanctionId: filters.sanctionId,
+			type: filters.type,
 			dateFrom: filters.dateFrom ? new Date(filters.dateFrom) : undefined,
 			dateTo: filters.dateTo ? new Date(filters.dateTo) : undefined,
 			limit: filters.limit ? parseInt(filters.limit) : 50,


### PR DESCRIPTION
## Summary
- Add nullable sanction_id and type column on users.appeals (migration 1776000700000)
- Make CreateAppealDto polymorphic: sanction (default) or blocked_image
- Validate blocked_image evidence (thumbnailBase64 <=100KB, conversationId, messageTempId)
- Skip sanction checks and liftSanction for blocked_image appeals
- Publish whispr:moderation:blocked_image_approved/rejected on review
- Allow filtering admin queries by type

## Test plan
- [x] Unit tests green (npx jest appeals --no-coverage -> 51 passed)
- [x] Full suite green (628 passed)
- [ ] CI pipeline green