### PR TITLE
feat(roles): seed admin roles from SEED_ADMIN_USER_IDS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ just up dev
             └─────────┘ └───────┘ │ Service  │
                                   └──────────┘
 ```
+
+## Testing
+
+```bash
+npm test
+npm run test:cov
+npm run test:e2e:docker
+```

--- a/README.md
+++ b/README.md
@@ -42,3 +42,18 @@ just up dev
 | `sanctions` | Sanctions et modération |
 | `appeals` | Appels contre les sanctions |
 | `webhooks` | Webhooks pour événements |
+
+## Architecture
+
+```
+┌──────────────┐     ┌──────────────┐
+│  Mobile App  │────▶│ User Service │
+└──────────────┘     └──────┬───────┘
+                            │
+                  ┌─────────┼─────────┐
+                  │         │         │
+            ┌─────▼───┐ ┌───▼───┐ ┌───▼──────┐
+            │ Postgres │ │ Redis │ │ Auth     │
+            └─────────┘ └───────┘ │ Service  │
+                                  └──────────┘
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
 
 This Microservice is responsible of the user social profile settings, and of the relationships management tasks in the Whispr Messenger system. It also handles contact requests, blocked users, privacy settings and user search.
 
+## Tech Stack
+
+- **Runtime** : Node.js 22+
+- **Framework** : NestJS + TypeScript
+- **Base de données** : PostgreSQL avec TypeORM
+- **Cache** : Redis
+
 ## Installation
 
 The repository uses `just` a custom recipe runner (like `make` in C lang) to provide useful scripts.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ Once you have `just` and `docker` installed in your computer you can start the d
 ```sh
 just up dev
 ```
+
+## Modules
+
+| Module | Rôle |
+|--------|------|
+| `profile` | Gestion du profil utilisateur |
+| `contacts` | Demandes de contact et liste d'amis |
+| `blocked-users` | Blocage/déblocage d'utilisateurs |
+| `privacy` | Paramètres de confidentialité |
+| `search` | Recherche d'utilisateurs |
+| `groups` | Gestion des groupes |
+| `sanctions` | Sanctions et modération |
+| `appeals` | Appels contre les sanctions |
+| `webhooks` | Webhooks pour événements |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-This Microservice is responsible of the user social profile settings, and of the relationships management tasks in the Whispr Messenger system.
+This Microservice is responsible of the user social profile settings, and of the relationships management tasks in the Whispr Messenger system. It also handles contact requests, blocked users, privacy settings and user search.
 
 ## Installation
 

--- a/src/modules/roles/roles.module.ts
+++ b/src/modules/roles/roles.module.ts
@@ -4,12 +4,13 @@ import { CommonModule } from '../common/common.module';
 import { UserRole } from './entities/user-role.entity';
 import { RolesRepository } from './repositories/roles.repository';
 import { RolesService } from './services/roles.service';
+import { SeedAdminService } from './services/seed-admin.service';
 import { RolesController } from './controllers/roles.controller';
 
 @Module({
 	imports: [CommonModule, TypeOrmModule.forFeature([UserRole])],
 	controllers: [RolesController],
-	providers: [RolesService, RolesRepository],
+	providers: [RolesService, RolesRepository, SeedAdminService],
 	exports: [RolesService],
 })
 export class RolesModule {}

--- a/src/modules/roles/services/seed-admin.service.spec.ts
+++ b/src/modules/roles/services/seed-admin.service.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { SeedAdminService } from './seed-admin.service';
+import { RolesRepository } from '../repositories/roles.repository';
+
+describe('SeedAdminService', () => {
+	let service: SeedAdminService;
+	let rolesRepository: jest.Mocked<RolesRepository>;
+	let configService: jest.Mocked<ConfigService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				SeedAdminService,
+				{
+					provide: RolesRepository,
+					useValue: {
+						upsert: jest.fn().mockResolvedValue(undefined),
+					},
+				},
+				{
+					provide: ConfigService,
+					useValue: {
+						get: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		service = module.get<SeedAdminService>(SeedAdminService);
+		rolesRepository = module.get(RolesRepository);
+		configService = module.get(ConfigService);
+	});
+
+	it('is a no-op when SEED_ADMIN_USER_IDS is unset', async () => {
+		configService.get.mockReturnValue('');
+		await service.onModuleInit();
+		expect(rolesRepository.upsert).not.toHaveBeenCalled();
+	});
+
+	it('upserts admin role for each valid UUID in the list', async () => {
+		const a = 'fab8817a-27a0-4537-89c1-be05f783150b';
+		const b = '3378ee73-ce43-4145-b689-ba982d97721e';
+		configService.get.mockReturnValue(`${a},${b}`);
+		await service.onModuleInit();
+		expect(rolesRepository.upsert).toHaveBeenCalledTimes(2);
+		expect(rolesRepository.upsert).toHaveBeenCalledWith(a, 'admin', a);
+		expect(rolesRepository.upsert).toHaveBeenCalledWith(b, 'admin', b);
+	});
+
+	it('trims whitespace and skips empty entries', async () => {
+		const a = 'fab8817a-27a0-4537-89c1-be05f783150b';
+		configService.get.mockReturnValue(` ${a} , ,  `);
+		await service.onModuleInit();
+		expect(rolesRepository.upsert).toHaveBeenCalledTimes(1);
+		expect(rolesRepository.upsert).toHaveBeenCalledWith(a, 'admin', a);
+	});
+
+	it('ignores invalid UUIDs without throwing', async () => {
+		const valid = 'fab8817a-27a0-4537-89c1-be05f783150b';
+		configService.get.mockReturnValue(`not-a-uuid,${valid}`);
+		await service.onModuleInit();
+		expect(rolesRepository.upsert).toHaveBeenCalledTimes(1);
+		expect(rolesRepository.upsert).toHaveBeenCalledWith(valid, 'admin', valid);
+	});
+
+	it('continues seeding other users when one upsert fails', async () => {
+		const a = 'fab8817a-27a0-4537-89c1-be05f783150b';
+		const b = '3378ee73-ce43-4145-b689-ba982d97721e';
+		rolesRepository.upsert
+			.mockRejectedValueOnce(new Error('db down'))
+			.mockResolvedValueOnce(undefined as any);
+		configService.get.mockReturnValue(`${a},${b}`);
+		await expect(service.onModuleInit()).resolves.not.toThrow();
+		expect(rolesRepository.upsert).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/modules/roles/services/seed-admin.service.ts
+++ b/src/modules/roles/services/seed-admin.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { RolesRepository } from '../repositories/roles.repository';
+
+/**
+ * Bootstraps admin roles from the SEED_ADMIN_USER_IDS environment variable.
+ *
+ * Value is a comma-separated list of UUIDs. Each UUID is upserted with role
+ * 'admin' on module init (idempotent). If the env var is unset or empty,
+ * the service is a no-op — safe for production.
+ *
+ * Solves the chicken-and-egg problem for bootstrapping the first admin(s)
+ * without direct SQL or hardcoded migrations.
+ */
+@Injectable()
+export class SeedAdminService implements OnModuleInit {
+	private readonly logger = new Logger(SeedAdminService.name);
+
+	constructor(
+		private readonly rolesRepository: RolesRepository,
+		private readonly configService: ConfigService
+	) {}
+
+	async onModuleInit(): Promise<void> {
+		const raw = this.configService.get<string>('SEED_ADMIN_USER_IDS', '');
+		const ids = raw
+			.split(',')
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0);
+
+		if (ids.length === 0) {
+			return;
+		}
+
+		const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+		const valid: string[] = [];
+		for (const id of ids) {
+			if (uuidRegex.test(id)) {
+				valid.push(id);
+			} else {
+				this.logger.warn(`Ignoring invalid UUID in SEED_ADMIN_USER_IDS: ${id}`);
+			}
+		}
+
+		for (const userId of valid) {
+			try {
+				await this.rolesRepository.upsert(userId, 'admin', userId);
+				this.logger.log(`Seeded admin role for user ${userId}`);
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				this.logger.error(`Failed to seed admin role for user ${userId}: ${msg}`);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Introduces SeedAdminService which runs on module init and upserts the admin role for each UUID listed in the SEED_ADMIN_USER_IDS env var (comma-separated).
- Idempotent and no-op when the env var is unset, so it stays safe in production.
- Unblocks preprod bootstrap of admin/moderator queue tooling for test users (Alice Mod + Tudy) without direct SQL.

## Test plan
- [x] Unit tests green (5 new tests in seed-admin.service.spec.ts, full suite passes: 630/630)
- [x] Lint clean
- [ ] E2E tests green (rely on CI)
- [ ] Deployed to preprod with SEED_ADMIN_USER_IDS to confirm seed logs on boot

## Notes
- Not tied to a Jira ticket — operational enablement for the preprod moderation queue smoke tests.