### PR TITLE
[WHISPR-1141] fix(profile): use blob URL instead of non-existent media.url field

### DIFF
--- a/src/modules/profile/controllers/profile.controller.spec.ts
+++ b/src/modules/profile/controllers/profile.controller.spec.ts
@@ -7,10 +7,19 @@ import { User } from '../../common/entities/user.entity';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
 
-const makeReq = (sub: string, authorization?: string): ExpressRequest & { user: JwtPayload } =>
+const makeReq = (
+	sub: string,
+	authorization?: string,
+	host = 'localhost:3000',
+	proto = 'http'
+): ExpressRequest & { user: JwtPayload } =>
 	({
 		user: { sub } as JwtPayload,
-		headers: authorization ? { authorization } : {},
+		headers: {
+			...(authorization ? { authorization } : {}),
+			host,
+			'x-forwarded-proto': proto,
+		},
 	}) as unknown as ExpressRequest & { user: JwtPayload };
 
 describe('ProfileController', () => {
@@ -69,7 +78,12 @@ describe('ProfileController', () => {
 
 			expect(result.id).toBe('user-1');
 			expect((result as any).phoneNumber).toBeUndefined();
-			expect(service.updateProfile).toHaveBeenCalledWith('user-1', dto, 'Bearer token');
+			expect(service.updateProfile).toHaveBeenCalledWith(
+				'user-1',
+				dto,
+				'Bearer token',
+				'http://localhost:3000'
+			);
 		});
 
 		it('passes undefined authorization when the header is missing', async () => {
@@ -79,7 +93,12 @@ describe('ProfileController', () => {
 
 			await controller.updateProfile('user-1', dto, makeReq('user-1'));
 
-			expect(service.updateProfile).toHaveBeenCalledWith('user-1', dto, undefined);
+			expect(service.updateProfile).toHaveBeenCalledWith(
+				'user-1',
+				dto,
+				undefined,
+				'http://localhost:3000'
+			);
 		});
 
 		it('throws Forbidden when the caller targets another user', async () => {

--- a/src/modules/profile/controllers/profile.controller.ts
+++ b/src/modules/profile/controllers/profile.controller.ts
@@ -53,7 +53,12 @@ export class ProfileController {
 	): Promise<UserResponseDto> {
 		assertOwnership(req, id, "Cannot update another user's profile");
 		const authorization = (req.headers['authorization'] as string | undefined) ?? undefined;
-		const user = await this.profileService.updateProfile(id, dto, authorization);
+
+		const proto = (req.headers['x-forwarded-proto'] as string) ?? 'http';
+		const host = (req.headers['x-forwarded-host'] as string) ?? (req.headers['host'] as string);
+		const requestBaseUrl = host ? `${proto}://${host}` : undefined;
+
+		const user = await this.profileService.updateProfile(id, dto, authorization, requestBaseUrl);
 		return UserResponseDto.fromEntity(user);
 	}
 }

--- a/src/modules/profile/services/media-client.service.spec.ts
+++ b/src/modules/profile/services/media-client.service.spec.ts
@@ -39,12 +39,14 @@ describe('MediaClientService', () => {
 	describe('getMediaMetadata', () => {
 		const validBody = {
 			id: 'media-1',
-			url: 'https://cdn.whispr.epitech.beer/avatars/media-1.webp',
-			thumbnailUrl: null,
-			context: 'avatar',
-			mimeType: 'image/webp',
-			sizeBytes: 1024,
 			ownerId: 'user-1',
+			context: 'avatar',
+			contentType: 'image/webp',
+			blobSize: 1024,
+			hasThumbnail: false,
+			isActive: true,
+			createdAt: '2026-04-01T00:00:00Z',
+			expiresAt: null,
 		};
 
 		it('returns metadata on success', async () => {

--- a/src/modules/profile/services/media-client.service.ts
+++ b/src/modules/profile/services/media-client.service.ts
@@ -4,21 +4,23 @@ import { ConfigService } from '@nestjs/config';
 /**
  * Lightweight HTTP client for the media-service.
  *
- * The media-service contract (see WHISPR-332):
- *   GET  /media/:id          → { id, url, thumbnailUrl, context, mimeType, ... }
- *   POST /media/upload       → multipart upload (handled by mobile/frontend)
+ * The media-service contract (MediaMetadataDto from Swagger):
+ *   GET  /media/v1/:id       → { id, ownerId, context, contentType, blobSize, ... }
+ *   POST /media/v1/upload    → multipart upload (handled by mobile/frontend)
  *
- * This client only needs to call GET /media/:id to resolve a mediaId
- * into a public URL for avatar storage.
+ * This client calls GET /media/v1/:id to validate a mediaId
+ * before storing the corresponding blob URL as the profile picture.
  */
 export interface MediaMetadata {
 	id: string;
-	url: string;
-	thumbnailUrl: string | null;
-	context: string;
-	mimeType: string;
-	sizeBytes: number;
 	ownerId: string;
+	context: string;
+	contentType: string;
+	blobSize: number;
+	hasThumbnail: boolean;
+	isActive: boolean;
+	createdAt: string;
+	expiresAt: string | null;
 }
 
 @Injectable()
@@ -30,13 +32,17 @@ export class MediaClientService {
 		this.baseUrl = this.configService.getOrThrow<string>('MEDIA_SERVICE_URL');
 	}
 
+	getBaseUrl(): string {
+		return this.baseUrl;
+	}
+
 	/**
 	 * Fetch media metadata from media-service by ID.
 	 *
 	 * @param mediaId  UUID of the uploaded media
 	 * @param userId   UUID of the requesting user (forwarded as x-user-id)
 	 * @param authorization Optional Authorization header from the caller ("Bearer ...")
-	 * @returns        MediaMetadata including the public URL
+	 * @returns        MediaMetadata as returned by the media-service
 	 */
 	async getMediaMetadata(mediaId: string, userId: string, authorization?: string): Promise<MediaMetadata> {
 		const url = `${this.baseUrl}/media/v1/${mediaId}`;

--- a/src/modules/profile/services/profile.service.spec.ts
+++ b/src/modules/profile/services/profile.service.spec.ts
@@ -26,12 +26,14 @@ const mockUser = (): User =>
 
 const mockMediaMetadata = (overrides: Partial<MediaMetadata> = {}): MediaMetadata => ({
 	id: 'media-uuid-1',
-	url: 'https://cdn.whispr.epitech.beer/avatars/media-uuid-1.webp',
-	thumbnailUrl: null,
-	context: 'avatar',
-	mimeType: 'image/webp',
-	sizeBytes: 12345,
 	ownerId: 'uuid-1',
+	context: 'avatar',
+	contentType: 'image/webp',
+	blobSize: 12345,
+	hasThumbnail: false,
+	isActive: true,
+	createdAt: '2026-04-01T00:00:00Z',
+	expiresAt: null,
 	...overrides,
 });
 
@@ -73,6 +75,7 @@ describe('ProfileService', () => {
 					provide: MediaClientService,
 					useValue: {
 						getMediaMetadata: jest.fn(),
+						getBaseUrl: jest.fn().mockReturnValue('http://media-service:3000'),
 					},
 				},
 				{
@@ -236,10 +239,24 @@ describe('ProfileService', () => {
 			mediaClient.getMediaMetadata.mockResolvedValue(metadata);
 			userRepository.save.mockImplementation(async (u) => u as User);
 
-			const result = await service.updateProfile('uuid-1', dto);
+			const result = await service.updateProfile('uuid-1', dto, undefined, 'https://api.whispr.beer');
 
 			expect(mediaClient.getMediaMetadata).toHaveBeenCalledWith('media-uuid-1', 'uuid-1', undefined);
-			expect(result.profilePictureUrl).toBe(metadata.url);
+			expect(result.profilePictureUrl).toBe('https://api.whispr.beer/media/v1/media-uuid-1/blob');
+		});
+
+		it('falls back to media-service base URL when requestBaseUrl is not provided', async () => {
+			const user = mockUser();
+			const metadata = mockMediaMetadata();
+			const dto: UpdateProfileDto = { avatarMediaId: 'media-uuid-1' };
+
+			userRepository.findById.mockResolvedValue(user);
+			mediaClient.getMediaMetadata.mockResolvedValue(metadata);
+			userRepository.save.mockImplementation(async (u) => u as User);
+
+			const result = await service.updateProfile('uuid-1', dto);
+
+			expect(result.profilePictureUrl).toBe('http://media-service:3000/media/v1/media-uuid-1/blob');
 		});
 
 		it('throws BadRequestException when media context is not avatar', async () => {
@@ -278,7 +295,7 @@ describe('ProfileService', () => {
 			const savedArg = userRepository.save.mock.calls[0][0] as any;
 			expect(savedArg.avatarMediaId).toBeUndefined();
 			expect(savedArg.firstName).toBe('Alice');
-			expect(savedArg.profilePictureUrl).toBe(metadata.url);
+			expect(savedArg.profilePictureUrl).toBe('http://media-service:3000/media/v1/media-uuid-1/blob');
 		});
 	});
 

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -63,7 +63,12 @@ export class ProfileService {
 		return masked;
 	}
 
-	public async updateProfile(id: string, dto: UpdateProfileDto, authorization?: string): Promise<User> {
+	public async updateProfile(
+		id: string,
+		dto: UpdateProfileDto,
+		authorization?: string,
+		requestBaseUrl?: string
+	): Promise<User> {
 		const user = await this.findOne(id);
 		const previousSnapshot = { ...user };
 
@@ -85,7 +90,8 @@ export class ProfileService {
 			if (media.ownerId !== id) {
 				throw new BadRequestException('Media does not belong to this user');
 			}
-			user.profilePictureUrl = media.url;
+			const base = requestBaseUrl?.replace(/\/+$/, '') ?? this.mediaClient.getBaseUrl();
+			user.profilePictureUrl = `${base}/media/v1/${dto.avatarMediaId}/blob`;
 		}
 
 		// Remove avatarMediaId before saving — it's not a DB column

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -90,7 +90,8 @@ export class ProfileService {
 			if (media.ownerId !== id) {
 				throw new BadRequestException('Media does not belong to this user');
 			}
-			const base = requestBaseUrl?.replace(/\/+$/, '') ?? this.mediaClient.getBaseUrl();
+			let base = requestBaseUrl ?? this.mediaClient.getBaseUrl();
+			while (base.endsWith('/')) base = base.slice(0, -1);
 			user.profilePictureUrl = `${base}/media/v1/${dto.avatarMediaId}/blob`;
 		}
 


### PR DESCRIPTION
## Summary\n- Fix `MediaMetadata` interface to match the actual `MediaMetadataDto` schema from the media-service Swagger (fields: `id`, `ownerId`, `context`, `contentType`, `blobSize`, `hasThumbnail`, `isActive`, `createdAt`, `expiresAt`)\n- Replace `media.url` (which was always `undefined`) with a constructed blob access URL (`/media/v1/{id}/blob`) built from `requestBaseUrl` or the media-service base URL as fallback\n- Pass `requestBaseUrl` from the controller (extracted from `x-forwarded-proto`/`x-forwarded-host`/`host` headers) to the profile service\n- Update all related unit tests to use the corrected schema and assertions\n\n## Test plan\n- [x] Unit tests green (762 passing)\n- [x] E2E tests green (7 passing)\n- [x] Lint clean\n\nCloses WHISPR-1141