### PR TITLE
chore(docs): update CLAUDE.md workflow to use worktrees and deploy/preprod

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ when picking up and completing a Jira ticket for this repository.
 
 - Jira cloud ID: `82ae2da5-7ee5-48f7-8877-a644651cd84b`
 - GitHub org/repo: `whispr-messenger/user-service`
-- Default base branch: `main`
+- Default base branch: `deploy/preprod`
 - Node package manager: `npm` (husky hooks run on commit and push)
 
 ---
@@ -26,11 +26,19 @@ when picking up and completing a Jira ticket for this repository.
 
 ## 2. Prepare the branch
 
+Always work in a **worktree** for isolation. Use `EnterWorktree` to create one,
+then reset it to `deploy/preprod`:
+
 ```bash
-git checkout main
-git pull origin main
+# Inside the worktree:
+git fetch origin deploy/preprod
+git reset --hard origin/deploy/preprod
 git checkout -b <TICKET-KEY>-<short-kebab-description>
 ```
+
+Before implementing, **enter Plan mode** to analyze the code and propose a
+step-by-step implementation plan. Only start coding after the user validates
+the plan.
 
 Branch naming convention: `WHISPR-XXX-short-description-of-the-fix`
 
@@ -236,7 +244,7 @@ fix, feature, refactor — must keep the `[WHISPR-XXX]` prefix.
   "repo": "user-service",
   "title": "[WHISPR-XXX] <type>(<scope>): <short imperative summary>",
   "head": "<branch-name>",
-  "base": "main",
+  "base": "deploy/preprod",
   "body": "## Summary\n- bullet 1\n- bullet 2\n\n## Test plan\n- [ ] Unit tests green\n- [ ] E2E tests green\n- [ ] Lint clean\n\nCloses <TICKET-KEY>"
 }
 ```
@@ -326,7 +334,7 @@ Once all CI checks are green, use `mcp__github__merge_pull_request`:
 }
 ```
 
-Always use **squash** merge to keep `main` history linear.
+Always use **squash** merge to keep `deploy/preprod` history linear.
 
 ---
 
@@ -337,11 +345,11 @@ Use `mcp__atlassian__transitionJiraIssue` with the transition whose `name` is
 
 ---
 
-## 11. Return to main and refresh the index
+## 11. Return to deploy/preprod and refresh the index
 
 ```bash
-git checkout main
-git pull origin main
+git checkout deploy/preprod
+git pull origin deploy/preprod
 npx gitnexus analyze --embeddings --force
 ```
 


### PR DESCRIPTION
## Summary\n- Switch base branch from `main` to `deploy/preprod` across all workflow sections\n- Add worktree isolation as mandatory step before implementation\n- Add plan mode requirement before coding\n\nNo Jira ticket — pure documentation/tooling update.