### PR TITLE
[WHISPR-1139] fix(profile): store mediaId instead of presigned URL for profilePictureUrl

### DIFF
--- a/src/modules/profile/controllers/profile.controller.spec.ts
+++ b/src/modules/profile/controllers/profile.controller.spec.ts
@@ -78,12 +78,7 @@ describe('ProfileController', () => {
 
 			expect(result.id).toBe('user-1');
 			expect((result as any).phoneNumber).toBeUndefined();
-			expect(service.updateProfile).toHaveBeenCalledWith(
-				'user-1',
-				dto,
-				'Bearer token',
-				'http://localhost:3000'
-			);
+			expect(service.updateProfile).toHaveBeenCalledWith('user-1', dto, 'Bearer token');
 		});
 
 		it('passes undefined authorization when the header is missing', async () => {
@@ -93,12 +88,7 @@ describe('ProfileController', () => {
 
 			await controller.updateProfile('user-1', dto, makeReq('user-1'));
 
-			expect(service.updateProfile).toHaveBeenCalledWith(
-				'user-1',
-				dto,
-				undefined,
-				'http://localhost:3000'
-			);
+			expect(service.updateProfile).toHaveBeenCalledWith('user-1', dto, undefined);
 		});
 
 		it('throws Forbidden when the caller targets another user', async () => {

--- a/src/modules/profile/controllers/profile.controller.ts
+++ b/src/modules/profile/controllers/profile.controller.ts
@@ -54,11 +54,7 @@ export class ProfileController {
 		assertOwnership(req, id, "Cannot update another user's profile");
 		const authorization = (req.headers['authorization'] as string | undefined) ?? undefined;
 
-		const proto = (req.headers['x-forwarded-proto'] as string) ?? 'http';
-		const host = (req.headers['x-forwarded-host'] as string) ?? (req.headers['host'] as string);
-		const requestBaseUrl = host ? `${proto}://${host}` : undefined;
-
-		const user = await this.profileService.updateProfile(id, dto, authorization, requestBaseUrl);
+		const user = await this.profileService.updateProfile(id, dto, authorization);
 		return UserResponseDto.fromEntity(user);
 	}
 }

--- a/src/modules/profile/services/media-client.service.spec.ts
+++ b/src/modules/profile/services/media-client.service.spec.ts
@@ -36,6 +36,13 @@ describe('MediaClientService', () => {
 		globalThis.fetch = originalFetch;
 	});
 
+	describe('resolveProfilePictureUrl', () => {
+		it('constructs the blob URL from a mediaId', () => {
+			const url = service.resolveProfilePictureUrl('media-uuid-1');
+			expect(url).toBe('http://media-service:3000/media/v1/media-uuid-1/blob');
+		});
+	});
+
 	describe('getMediaMetadata', () => {
 		const validBody = {
 			id: 'media-1',

--- a/src/modules/profile/services/media-client.service.ts
+++ b/src/modules/profile/services/media-client.service.ts
@@ -36,6 +36,10 @@ export class MediaClientService {
 		return this.baseUrl;
 	}
 
+	resolveProfilePictureUrl(mediaId: string): string {
+		return `${this.baseUrl}/media/v1/${mediaId}/blob`;
+	}
+
 	/**
 	 * Fetch media metadata from media-service by ID.
 	 *

--- a/src/modules/profile/services/profile.service.spec.ts
+++ b/src/modules/profile/services/profile.service.spec.ts
@@ -76,6 +76,11 @@ describe('ProfileService', () => {
 					useValue: {
 						getMediaMetadata: jest.fn(),
 						getBaseUrl: jest.fn().mockReturnValue('http://media-service:3000'),
+						resolveProfilePictureUrl: jest
+							.fn()
+							.mockImplementation(
+								(id: string) => `http://media-service:3000/media/v1/${id}/blob`
+							),
 					},
 				},
 				{
@@ -117,6 +122,25 @@ describe('ProfileService', () => {
 
 			expect(result).toBe(user);
 			expect(userRepository.findById).toHaveBeenCalledWith('uuid-1');
+		});
+
+		it('resolves profilePictureUrl to blob URL when set', async () => {
+			const user = { ...mockUser(), profilePictureUrl: 'media-uuid-1' } as User;
+			userRepository.findById.mockResolvedValue(user);
+
+			const result = await service.getProfile('uuid-1');
+
+			expect(result.profilePictureUrl).toBe('http://media-service:3000/media/v1/media-uuid-1/blob');
+		});
+
+		it('returns null profilePictureUrl when not set', async () => {
+			const user = mockUser();
+			userRepository.findById.mockResolvedValue(user);
+
+			const result = await service.getProfile('uuid-1');
+
+			expect(result.profilePictureUrl).toBeNull();
+			expect(mediaClient.resolveProfilePictureUrl).not.toHaveBeenCalled();
 		});
 
 		it('throws NotFoundException when user does not exist', async () => {
@@ -230,32 +254,25 @@ describe('ProfileService', () => {
 	});
 
 	describe('updateProfile with avatarMediaId', () => {
-		it('resolves avatarMediaId to profilePictureUrl via media-service', async () => {
+		it('stores the raw mediaId and returns a resolved blob URL', async () => {
 			const user = mockUser();
 			const metadata = mockMediaMetadata();
 			const dto: UpdateProfileDto = { avatarMediaId: 'media-uuid-1' };
 
 			userRepository.findById.mockResolvedValue(user);
 			mediaClient.getMediaMetadata.mockResolvedValue(metadata);
-			userRepository.save.mockImplementation(async (u) => u as User);
-
-			const result = await service.updateProfile('uuid-1', dto, undefined, 'https://api.whispr.beer');
-
-			expect(mediaClient.getMediaMetadata).toHaveBeenCalledWith('media-uuid-1', 'uuid-1', undefined);
-			expect(result.profilePictureUrl).toBe('https://api.whispr.beer/media/v1/media-uuid-1/blob');
-		});
-
-		it('falls back to media-service base URL when requestBaseUrl is not provided', async () => {
-			const user = mockUser();
-			const metadata = mockMediaMetadata();
-			const dto: UpdateProfileDto = { avatarMediaId: 'media-uuid-1' };
-
-			userRepository.findById.mockResolvedValue(user);
-			mediaClient.getMediaMetadata.mockResolvedValue(metadata);
-			userRepository.save.mockImplementation(async (u) => u as User);
+			let savedProfilePictureUrl: string | null = null;
+			userRepository.save.mockImplementation(async (u) => {
+				savedProfilePictureUrl = (u as User).profilePictureUrl;
+				return u as User;
+			});
 
 			const result = await service.updateProfile('uuid-1', dto);
 
+			expect(mediaClient.getMediaMetadata).toHaveBeenCalledWith('media-uuid-1', 'uuid-1', undefined);
+			// DB receives the raw mediaId
+			expect(savedProfilePictureUrl).toBe('media-uuid-1');
+			// Returned value is the resolved URL
 			expect(result.profilePictureUrl).toBe('http://media-service:3000/media/v1/media-uuid-1/blob');
 		});
 
@@ -288,14 +305,17 @@ describe('ProfileService', () => {
 
 			userRepository.findById.mockResolvedValue(user);
 			mediaClient.getMediaMetadata.mockResolvedValue(metadata);
-			userRepository.save.mockImplementation(async (u) => u as User);
+			let savedSnapshot: Record<string, unknown> = {};
+			userRepository.save.mockImplementation(async (u) => {
+				savedSnapshot = { ...(u as any) };
+				return u as User;
+			});
 
 			await service.updateProfile('uuid-1', dto);
 
-			const savedArg = userRepository.save.mock.calls[0][0] as any;
-			expect(savedArg.avatarMediaId).toBeUndefined();
-			expect(savedArg.firstName).toBe('Alice');
-			expect(savedArg.profilePictureUrl).toBe('http://media-service:3000/media/v1/media-uuid-1/blob');
+			expect(savedSnapshot.avatarMediaId).toBeUndefined();
+			expect(savedSnapshot.firstName).toBe('Alice');
+			expect(savedSnapshot.profilePictureUrl).toBe('media-uuid-1');
 		});
 	});
 
@@ -306,8 +326,30 @@ describe('ProfileService', () => {
 
 			const result = await service.getProfileWithPrivacy('uuid-1', 'uuid-1');
 
-			expect(result).toBe(user);
+			expect(result.firstName).toBe('Alice');
+			expect(result.lastName).toBe('Smith');
 			expect(privacyService.getSettings).not.toHaveBeenCalled();
+		});
+
+		it('resolves profilePictureUrl for owner', async () => {
+			const user = { ...mockUser(), profilePictureUrl: 'media-uuid-1' } as User;
+			userRepository.findById.mockResolvedValue(user);
+
+			const result = await service.getProfileWithPrivacy('uuid-1', 'uuid-1');
+
+			expect(result.profilePictureUrl).toBe('http://media-service:3000/media/v1/media-uuid-1/blob');
+		});
+
+		it('returns null profilePictureUrl when user has no avatar', async () => {
+			const user = mockUser();
+			userRepository.findById.mockResolvedValue(user);
+			privacyService.getSettings.mockResolvedValue(mockPrivacySettings());
+			contactsService.isContact.mockResolvedValue(false);
+
+			const result = await service.getProfileWithPrivacy('uuid-1', 'uuid-2');
+
+			expect(result.profilePictureUrl).toBeNull();
+			expect(mediaClient.resolveProfilePictureUrl).not.toHaveBeenCalled();
 		});
 
 		it('returns full profile when all fields are set to EVERYONE', async () => {
@@ -316,7 +358,7 @@ describe('ProfileService', () => {
 				firstName: 'Alice',
 				lastName: 'Smith',
 				biography: 'Hello',
-				profilePictureUrl: 'https://cdn.example.com/pic.jpg',
+				profilePictureUrl: 'media-uuid-1',
 				lastSeen: new Date(),
 			} as User;
 			userRepository.findById.mockResolvedValue(user);
@@ -328,7 +370,7 @@ describe('ProfileService', () => {
 			expect(result.firstName).toBe('Alice');
 			expect(result.lastName).toBe('Smith');
 			expect(result.biography).toBe('Hello');
-			expect(result.profilePictureUrl).toBe('https://cdn.example.com/pic.jpg');
+			expect(result.profilePictureUrl).toBe('http://media-service:3000/media/v1/media-uuid-1/blob');
 		});
 
 		it('masks fields set to NOBODY when requester is not the owner', async () => {
@@ -337,7 +379,7 @@ describe('ProfileService', () => {
 				firstName: 'Alice',
 				lastName: 'Smith',
 				biography: 'Hello',
-				profilePictureUrl: 'https://cdn.example.com/pic.jpg',
+				profilePictureUrl: 'media-uuid-1',
 				lastSeen: new Date(),
 			} as User;
 			userRepository.findById.mockResolvedValue(user);

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -37,13 +37,22 @@ export class ProfileService {
 	}
 
 	public async getProfile(id: string): Promise<User> {
-		return this.findOne(id);
+		const user = await this.findOne(id);
+		if (user.profilePictureUrl) {
+			user.profilePictureUrl = this.mediaClient.resolveProfilePictureUrl(user.profilePictureUrl);
+		}
+		return user;
 	}
 
 	public async getProfileWithPrivacy(id: string, requesterId: string): Promise<User> {
 		const user = await this.findOne(id);
 
-		if (requesterId === id) return user;
+		if (requesterId === id) {
+			if (user.profilePictureUrl) {
+				user.profilePictureUrl = this.mediaClient.resolveProfilePictureUrl(user.profilePictureUrl);
+			}
+			return user;
+		}
 
 		const settings = await this.privacyService.getSettings(id);
 		const isContact = await this.contactsService.isContact(id, requesterId);
@@ -60,15 +69,13 @@ export class ProfileService {
 		if (!canSee(settings.biographyPrivacy)) masked.biography = null;
 		if (!canSee(settings.profilePicturePrivacy)) masked.profilePictureUrl = null;
 		if (!canSee(settings.lastSeenPrivacy)) masked.lastSeen = null;
+		if (masked.profilePictureUrl) {
+			masked.profilePictureUrl = this.mediaClient.resolveProfilePictureUrl(masked.profilePictureUrl);
+		}
 		return masked;
 	}
 
-	public async updateProfile(
-		id: string,
-		dto: UpdateProfileDto,
-		authorization?: string,
-		requestBaseUrl?: string
-	): Promise<User> {
+	public async updateProfile(id: string, dto: UpdateProfileDto, authorization?: string): Promise<User> {
 		const user = await this.findOne(id);
 		const previousSnapshot = { ...user };
 
@@ -90,9 +97,7 @@ export class ProfileService {
 			if (media.ownerId !== id) {
 				throw new BadRequestException('Media does not belong to this user');
 			}
-			let base = requestBaseUrl ?? this.mediaClient.getBaseUrl();
-			while (base.endsWith('/')) base = base.slice(0, -1);
-			user.profilePictureUrl = `${base}/media/v1/${dto.avatarMediaId}/blob`;
+			user.profilePictureUrl = dto.avatarMediaId;
 		}
 
 		// Remove avatarMediaId before saving — it's not a DB column
@@ -116,6 +121,9 @@ export class ProfileService {
 			}
 		}
 
+		if (saved.profilePictureUrl) {
+			saved.profilePictureUrl = this.mediaClient.resolveProfilePictureUrl(saved.profilePictureUrl);
+		}
 		return saved;
 	}
 }


### PR DESCRIPTION
## Summary

- **Store only the raw `mediaId` (UUID) in `profilePictureUrl`** instead of a constructed blob URL that depended on the request gateway host
- **Resolve the full blob URL at read time** via `MediaClientService.resolveProfilePictureUrl()` in `getProfile`, `getProfileWithPrivacy`, and `updateProfile` return paths
- **Remove `requestBaseUrl` parameter** from `updateProfile` — the URL is now always resolved from `MEDIA_SERVICE_URL` config, making it infrastructure-agnostic

## Test plan

- [x] Unit tests green (769 tests, 80 suites)
- [x] E2E tests green (Docker stack)
- [x] Lint clean (eslint + prettier)
- [x] `save()` receives a UUID, not a URL
- [x] API responses contain resolved blob URLs
- [x] Privacy masking returns `null` when access is denied
- [x] Owner path resolves URL correctly

Closes WHISPR-1139