### PR TITLE
[WHISPR-1188] feat(profile): add GET /profile/me endpoint

### DIFF
--- a/src/modules/profile/controllers/profile.controller.spec.ts
+++ b/src/modules/profile/controllers/profile.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import type { Request as ExpressRequest } from 'express';
 import { ProfileController } from './profile.controller';
 import { ProfileService } from '../services/profile.service';
@@ -33,6 +33,7 @@ describe('ProfileController', () => {
 				{
 					provide: ProfileService,
 					useValue: {
+						getProfile: jest.fn(),
 						getProfileWithPrivacy: jest.fn(),
 						updateProfile: jest.fn(),
 					},
@@ -42,6 +43,37 @@ describe('ProfileController', () => {
 
 		controller = module.get<ProfileController>(ProfileController);
 		service = module.get(ProfileService);
+	});
+
+	describe('getMyProfile', () => {
+		it('returns a SelfProfileResponseDto including phoneNumber for req.user.sub', async () => {
+			const user = {
+				id: 'user-1',
+				phoneNumber: '+33600000001',
+				username: 'alice',
+				firstName: 'Alice',
+				lastName: null,
+				biography: null,
+				profilePictureUrl: null,
+				lastSeen: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			} as User;
+			(service as any).getProfile.mockResolvedValue(user);
+
+			const result = await controller.getMyProfile(makeReq('user-1'));
+
+			expect(result.id).toBe('user-1');
+			expect(result.phoneNumber).toBe('+33600000001');
+			expect(result.username).toBe('alice');
+			expect((service as any).getProfile).toHaveBeenCalledWith('user-1');
+		});
+
+		it('propagates NotFoundException from the service', async () => {
+			(service as any).getProfile.mockRejectedValue(new NotFoundException('User not found'));
+
+			await expect(controller.getMyProfile(makeReq('missing-user'))).rejects.toThrow(NotFoundException);
+		});
 	});
 
 	describe('getProfile', () => {

--- a/src/modules/profile/controllers/profile.controller.ts
+++ b/src/modules/profile/controllers/profile.controller.ts
@@ -4,6 +4,7 @@ import { SkipThrottle } from '@nestjs/throttler';
 import { ProfileService } from '../services/profile.service';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
 import { UserResponseDto } from '../../common/dto/user-response.dto';
+import { SelfProfileResponseDto } from '../dto/self-profile-response.dto';
 import type { Request as ExpressRequest } from 'express';
 import { JwtPayload } from '../../jwt-auth/jwt.strategy';
 import { assertOwnership } from '../../jwt-auth/ownership.util';
@@ -13,6 +14,23 @@ import { assertOwnership } from '../../jwt-auth/ownership.util';
 @Controller('profile')
 export class ProfileController {
 	constructor(private readonly profileService: ProfileService) {}
+
+	@Get('me')
+	@SkipThrottle()
+	@ApiOperation({ summary: 'Get my own profile (includes phoneNumber)' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Profile retrieved successfully',
+		type: SelfProfileResponseDto,
+	})
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
+	async getMyProfile(
+		@Request() req: ExpressRequest & { user: JwtPayload }
+	): Promise<SelfProfileResponseDto> {
+		const user = await this.profileService.getProfile(req.user.sub);
+		return SelfProfileResponseDto.fromEntity(user);
+	}
 
 	@Get(':id')
 	@SkipThrottle()

--- a/src/modules/profile/dto/self-profile-response.dto.ts
+++ b/src/modules/profile/dto/self-profile-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from '../../common/entities/user.entity';
+import { UserResponseDto } from '../../common/dto/user-response.dto';
+
+export class SelfProfileResponseDto extends UserResponseDto {
+	@ApiProperty({ description: 'User phone number in E.164 format' })
+	phoneNumber: string;
+
+	static fromEntity(user: User): SelfProfileResponseDto {
+		const base = UserResponseDto.fromEntity(user);
+		const dto = new SelfProfileResponseDto();
+		Object.assign(dto, base);
+		dto.phoneNumber = user.phoneNumber;
+		return dto;
+	}
+}

--- a/test/functional.e2e-spec.ts
+++ b/test/functional.e2e-spec.ts
@@ -132,6 +132,26 @@ describe('Functional E2E Scenarios', () => {
 		});
 	});
 
+	// Scenario 1b: GET /profile/me returns authenticated profile with phoneNumber
+	describe('Scenario 1b: Get own profile via /profile/me', () => {
+		it('should return 200 with phoneNumber for the authenticated user', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+
+			const res = await request(app.getHttpServer())
+				.get('/user/v1/profile/me')
+				.set(asUser(USER_A_ID))
+				.expect(200);
+
+			expect(res.body.id).toBe(USER_A_ID);
+			expect(res.body.phoneNumber).toBe('+33600000001');
+			expect(res.body.username).toBe('alice');
+		});
+
+		it('should return 401 without a bearer token', async () => {
+			await request(app.getHttpServer()).get('/user/v1/profile/me').expect(401);
+		});
+	});
+
 	// Scenario 2: PATCH /profile/:id of another user returns 403
 	describe('Scenario 2: Cannot update another user profile', () => {
 		it('should return 403 when updating another user profile', async () => {


### PR DESCRIPTION
## Summary

- Add `GET /profile/me` that returns the full profile of the authenticated user, **including `phoneNumber`**.
- New `SelfProfileResponseDto` extends `UserResponseDto` with `phoneNumber` — isolates the surface so `UserResponseDto` (used by `/profile/:id`, `/search`, `/contacts`, …) never accidentally leaks the number cross-user.
- Reuses existing `ProfileService.getProfile(id)` which already bypasses privacy masking and resolves the avatar URL via the media-service. No new service method.
- Route is declared **before** `@Get(':id')` so NestJS matches `/profile/me` before `ParseUUIDPipe` rejects it as 400.
- Follows the `@Get('me')` convention already established by `roles/me`, `sanctions/me`, `reputation/me`.

## Motivation

Mobile (WHISPR-1186) needs the authenticated user's phone number in `ProfileSetupScreen` after OTP. `/profile/:id` deliberately omits `phoneNumber` to prevent cross-user leakage, so calling it on one's own id wasn't enough.

## Test plan

- [x] Unit tests green (`profile.controller.spec.ts` — 2 new cases: success + `NotFoundException` propagation)
- [x] E2E tests green (`functional.e2e-spec.ts` — Scenario 1b: 200 with `phoneNumber` + 401 without bearer)
- [x] Lint + Prettier clean (husky pre-commit ran)
- [x] Full unit test suite green (pre-push hook)
- [x] Swagger documented (`@ApiOperation`, `@ApiResponse` typed with `SelfProfileResponseDto`)

Closes WHISPR-1188