### PR TITLE
[WHISPR-1229] feat(internal): add /internal/v1/contacts/check endpoint

### DIFF
--- a/src/docker/check-env/env-config.ts
+++ b/src/docker/check-env/env-config.ts
@@ -16,6 +16,7 @@ export const USER_SERVICE_ENV_CONFIG: EnvCheckConfig = {
 		'JWT_ISSUER',
 		'JWT_AUDIENCE',
 		'MEDIA_SERVICE_URL',
+		'INTERNAL_API_TOKEN',
 	],
 	optional: [
 		{ name: 'DB_URL', default: '(constructed from individual DB vars)' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { Logger, ValidationPipe, VersioningType } from '@nestjs/common';
+import { Logger, RequestMethod, ValidationPipe, VersioningType } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { ConfigService } from '@nestjs/config';
 import { json, urlencoded } from 'express';
@@ -58,7 +58,9 @@ export async function bootstrap() {
 	app.use(json({ limit: '2mb' }));
 	app.use(urlencoded({ limit: '2mb', extended: true }));
 
-	app.setGlobalPrefix(globalPrefix);
+	app.setGlobalPrefix(globalPrefix, {
+		exclude: [{ path: 'internal/(.*)', method: RequestMethod.ALL }],
+	});
 
 	app.enableVersioning({
 		type: VersioningType.URI,

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -24,6 +24,7 @@ import { ModerationSubscriberModule } from './moderation-subscriber/moderation-s
 import { ReputationModule } from './reputation/reputation.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { BackupsModule } from './backups/backups.module';
+import { InternalModule } from './internal/internal.module';
 import { JwtAuthModule } from './jwt-auth/jwt-auth.module';
 import { JwtAuthGuard } from './jwt-auth/jwt-auth.guard';
 
@@ -58,6 +59,7 @@ const GLOBAL_THROTTLE_LIMIT = 300;
 		ReputationModule,
 		WebhooksModule,
 		BackupsModule,
+		InternalModule,
 	],
 	providers: [
 		{

--- a/src/modules/blocked-users/repositories/blocked-users.repository.spec.ts
+++ b/src/modules/blocked-users/repositories/blocked-users.repository.spec.ts
@@ -80,6 +80,43 @@ describe('BlockedUsersRepository', () => {
 		});
 	});
 
+	describe('existsEitherDirection', () => {
+		const mockQb = {
+			where: jest.fn().mockReturnThis(),
+			limit: jest.fn().mockReturnThis(),
+			getCount: jest.fn(),
+		};
+
+		beforeEach(() => {
+			(mockTypeormRepo as any).createQueryBuilder = jest.fn().mockReturnValue(mockQb);
+			mockQb.where.mockClear();
+			mockQb.limit.mockClear();
+			mockQb.getCount.mockClear();
+			mockQb.where.mockReturnValue(mockQb);
+			mockQb.limit.mockReturnValue(mockQb);
+		});
+
+		it('returns true when a block exists in either direction', async () => {
+			mockQb.getCount.mockResolvedValue(1);
+
+			const result = await repo.existsEitherDirection('user-a', 'user-b');
+
+			expect(mockQb.where).toHaveBeenCalledWith(expect.any(String), {
+				userA: 'user-a',
+				userB: 'user-b',
+			});
+			expect(result).toBe(true);
+		});
+
+		it('returns false when no block exists', async () => {
+			mockQb.getCount.mockResolvedValue(0);
+
+			const result = await repo.existsEitherDirection('user-a', 'user-b');
+
+			expect(result).toBe(false);
+		});
+	});
+
 	describe('findAllByBlockerPaginated', () => {
 		const mockQb = {
 			leftJoinAndSelect: jest.fn().mockReturnThis(),

--- a/src/modules/blocked-users/repositories/blocked-users.repository.spec.ts
+++ b/src/modules/blocked-users/repositories/blocked-users.repository.spec.ts
@@ -7,6 +7,7 @@ const mockTypeormRepo = {
 	findOne: jest.fn(),
 	find: jest.fn(),
 	remove: jest.fn(),
+	exists: jest.fn(),
 };
 
 describe('BlockedUsersRepository', () => {
@@ -81,35 +82,22 @@ describe('BlockedUsersRepository', () => {
 	});
 
 	describe('existsEitherDirection', () => {
-		const mockQb = {
-			where: jest.fn().mockReturnThis(),
-			limit: jest.fn().mockReturnThis(),
-			getCount: jest.fn(),
-		};
-
-		beforeEach(() => {
-			(mockTypeormRepo as any).createQueryBuilder = jest.fn().mockReturnValue(mockQb);
-			mockQb.where.mockClear();
-			mockQb.limit.mockClear();
-			mockQb.getCount.mockClear();
-			mockQb.where.mockReturnValue(mockQb);
-			mockQb.limit.mockReturnValue(mockQb);
-		});
-
 		it('returns true when a block exists in either direction', async () => {
-			mockQb.getCount.mockResolvedValue(1);
+			mockTypeormRepo.exists.mockResolvedValue(true);
 
 			const result = await repo.existsEitherDirection('user-a', 'user-b');
 
-			expect(mockQb.where).toHaveBeenCalledWith(expect.any(String), {
-				userA: 'user-a',
-				userB: 'user-b',
+			expect(mockTypeormRepo.exists).toHaveBeenCalledWith({
+				where: [
+					{ blockerId: 'user-a', blockedId: 'user-b' },
+					{ blockerId: 'user-b', blockedId: 'user-a' },
+				],
 			});
 			expect(result).toBe(true);
 		});
 
 		it('returns false when no block exists', async () => {
-			mockQb.getCount.mockResolvedValue(0);
+			mockTypeormRepo.exists.mockResolvedValue(false);
 
 			const result = await repo.existsEitherDirection('user-a', 'user-b');
 

--- a/src/modules/blocked-users/repositories/blocked-users.repository.ts
+++ b/src/modules/blocked-users/repositories/blocked-users.repository.ts
@@ -33,15 +33,12 @@ export class BlockedUsersRepository {
 	}
 
 	async existsEitherDirection(userA: string, userB: string): Promise<boolean> {
-		const count = await this.repo
-			.createQueryBuilder('blocked')
-			.where(
-				'(blocked.blockerId = :userA AND blocked.blockedId = :userB) OR (blocked.blockerId = :userB AND blocked.blockedId = :userA)',
-				{ userA, userB }
-			)
-			.limit(1)
-			.getCount();
-		return count > 0;
+		return this.repo.exists({
+			where: [
+				{ blockerId: userA, blockedId: userB },
+				{ blockerId: userB, blockedId: userA },
+			],
+		});
 	}
 
 	async create(blockerId: string, blockedId: string): Promise<BlockedUser> {

--- a/src/modules/blocked-users/repositories/blocked-users.repository.ts
+++ b/src/modules/blocked-users/repositories/blocked-users.repository.ts
@@ -32,6 +32,18 @@ export class BlockedUsersRepository {
 		return this.repo.findOne({ where: { blockerId, blockedId } });
 	}
 
+	async existsEitherDirection(userA: string, userB: string): Promise<boolean> {
+		const count = await this.repo
+			.createQueryBuilder('blocked')
+			.where(
+				'(blocked.blockerId = :userA AND blocked.blockedId = :userB) OR (blocked.blockerId = :userB AND blocked.blockedId = :userA)',
+				{ userA, userB }
+			)
+			.limit(1)
+			.getCount();
+		return count > 0;
+	}
+
 	async create(blockerId: string, blockedId: string): Promise<BlockedUser> {
 		const blockedUser = this.repo.create({ blockerId, blockedId });
 		return this.repo.save(blockedUser);

--- a/src/modules/blocked-users/services/blocked-users.service.spec.ts
+++ b/src/modules/blocked-users/services/blocked-users.service.spec.ts
@@ -51,6 +51,7 @@ describe('BlockedUsersService', () => {
 						findOne: jest.fn(),
 						create: jest.fn(),
 						remove: jest.fn(),
+						existsEitherDirection: jest.fn(),
 					},
 				},
 			],
@@ -152,6 +153,25 @@ describe('BlockedUsersService', () => {
 			await expect(service.blockUser('uuid-1', { blockedId: 'uuid-2' })).rejects.toThrow(
 				ConflictException
 			);
+		});
+	});
+
+	describe('isBlockedEitherWay', () => {
+		it('delegates to repository.existsEitherDirection and returns the result', async () => {
+			blockedUsersRepository.existsEitherDirection.mockResolvedValue(true);
+
+			const result = await service.isBlockedEitherWay('uuid-1', 'uuid-2');
+
+			expect(blockedUsersRepository.existsEitherDirection).toHaveBeenCalledWith('uuid-1', 'uuid-2');
+			expect(result).toBe(true);
+		});
+
+		it('returns false when no block exists in either direction', async () => {
+			blockedUsersRepository.existsEitherDirection.mockResolvedValue(false);
+
+			const result = await service.isBlockedEitherWay('uuid-1', 'uuid-2');
+
+			expect(result).toBe(false);
 		});
 	});
 

--- a/src/modules/blocked-users/services/blocked-users.service.ts
+++ b/src/modules/blocked-users/services/blocked-users.service.ts
@@ -44,6 +44,10 @@ export class BlockedUsersService {
 		return this.blockedUsersRepository.create(blockerId, dto.blockedId);
 	}
 
+	async isBlockedEitherWay(userA: string, userB: string): Promise<boolean> {
+		return this.blockedUsersRepository.existsEitherDirection(userA, userB);
+	}
+
 	async unblockUser(blockerId: string, blockedId: string): Promise<void> {
 		await this.ensureUserExists(blockerId);
 

--- a/src/modules/internal/contacts/dto/check-contact-query.dto.ts
+++ b/src/modules/internal/contacts/dto/check-contact-query.dto.ts
@@ -1,0 +1,18 @@
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class CheckContactQueryDto {
+	@ApiProperty({ description: 'UUID of the contact list owner', format: 'uuid' })
+	@IsString()
+	@IsNotEmpty({ message: 'ownerId is required' })
+	@Matches(UUID_REGEX, { message: 'ownerId must be a valid UUID' })
+	ownerId: string;
+
+	@ApiProperty({ description: 'UUID of the user to check against the owner', format: 'uuid' })
+	@IsString()
+	@IsNotEmpty({ message: 'contactId is required' })
+	@Matches(UUID_REGEX, { message: 'contactId must be a valid UUID' })
+	contactId: string;
+}

--- a/src/modules/internal/contacts/dto/check-contact-query.dto.ts
+++ b/src/modules/internal/contacts/dto/check-contact-query.dto.ts
@@ -1,18 +1,16 @@
-import { IsNotEmpty, IsString, Matches } from 'class-validator';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export class CheckContactQueryDto {
 	@ApiProperty({ description: 'UUID of the contact list owner', format: 'uuid' })
 	@IsString()
 	@IsNotEmpty({ message: 'ownerId is required' })
-	@Matches(UUID_REGEX, { message: 'ownerId must be a valid UUID' })
+	@IsUUID(undefined, { message: 'ownerId must be a valid UUID' })
 	ownerId: string;
 
 	@ApiProperty({ description: 'UUID of the user to check against the owner', format: 'uuid' })
 	@IsString()
 	@IsNotEmpty({ message: 'contactId is required' })
-	@Matches(UUID_REGEX, { message: 'contactId must be a valid UUID' })
+	@IsUUID(undefined, { message: 'contactId must be a valid UUID' })
 	contactId: string;
 }

--- a/src/modules/internal/contacts/dto/check-contact-response.dto.ts
+++ b/src/modules/internal/contacts/dto/check-contact-response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CheckContactResponseDto {
+	@ApiProperty({
+		description: 'True when the (ownerId, contactId) pair exists in users.contacts',
+	})
+	isContact: boolean;
+
+	@ApiProperty({
+		description: 'True when either user has blocked the other',
+	})
+	isBlocked: boolean;
+}

--- a/src/modules/internal/contacts/internal-contacts.controller.spec.ts
+++ b/src/modules/internal/contacts/internal-contacts.controller.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { InternalContactsController } from './internal-contacts.controller';
+import { InternalContactsService } from './internal-contacts.service';
+import { CheckContactQueryDto } from './dto/check-contact-query.dto';
+
+describe('InternalContactsController', () => {
+	let controller: InternalContactsController;
+	let service: jest.Mocked<InternalContactsService>;
+
+	const OWNER_ID = 'a0000000-0000-4000-a000-000000000001';
+	const CONTACT_ID = 'b0000000-0000-4000-b000-000000000002';
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [InternalContactsController],
+			providers: [
+				{
+					provide: InternalContactsService,
+					useValue: { checkContactRelation: jest.fn() },
+				},
+				{
+					provide: ConfigService,
+					useValue: { get: jest.fn().mockReturnValue('test-token') },
+				},
+			],
+		}).compile();
+
+		controller = module.get(InternalContactsController);
+		service = module.get(InternalContactsService);
+	});
+
+	describe('check', () => {
+		it('delegates to the service and returns the response payload', async () => {
+			service.checkContactRelation.mockResolvedValue({ isContact: true, isBlocked: false });
+			const query: CheckContactQueryDto = { ownerId: OWNER_ID, contactId: CONTACT_ID };
+
+			const result = await controller.check(query);
+
+			expect(service.checkContactRelation).toHaveBeenCalledWith(OWNER_ID, CONTACT_ID);
+			expect(result).toEqual({ isContact: true, isBlocked: false });
+		});
+	});
+});

--- a/src/modules/internal/contacts/internal-contacts.controller.ts
+++ b/src/modules/internal/contacts/internal-contacts.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, HttpStatus, Query, UseGuards, VERSION_NEUTRAL } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { Public } from '../../jwt-auth/public.decorator';
+import { InternalAuthGuard } from '../internal-auth.guard';
+import { InternalContactsService } from './internal-contacts.service';
+import { CheckContactQueryDto } from './dto/check-contact-query.dto';
+import { CheckContactResponseDto } from './dto/check-contact-response.dto';
+
+@ApiTags('Internal')
+@ApiSecurity('internal-token')
+@Public()
+@UseGuards(InternalAuthGuard)
+@Controller({ path: 'internal/v1/contacts', version: VERSION_NEUTRAL })
+export class InternalContactsController {
+	constructor(private readonly internalContactsService: InternalContactsService) {}
+
+	@Get('check')
+	@ApiOperation({
+		summary: 'Check whether two users are contacts and not blocked (machine-to-machine)',
+		description:
+			'Internal endpoint consumed by other Whispr services (e.g. messaging-service) to authorise direct conversations. Not exposed by the public API gateway.',
+	})
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Relationship resolved (always 200, even when no contact row exists)',
+		type: CheckContactResponseDto,
+	})
+	@ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'ownerId or contactId is not a UUID' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid internal token' })
+	async check(@Query() query: CheckContactQueryDto): Promise<CheckContactResponseDto> {
+		return this.internalContactsService.checkContactRelation(query.ownerId, query.contactId);
+	}
+}

--- a/src/modules/internal/contacts/internal-contacts.service.spec.ts
+++ b/src/modules/internal/contacts/internal-contacts.service.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InternalContactsService } from './internal-contacts.service';
+import { ContactsService } from '../../contacts/services/contacts.service';
+import { BlockedUsersService } from '../../blocked-users/services/blocked-users.service';
+
+describe('InternalContactsService', () => {
+	let service: InternalContactsService;
+	let contactsService: jest.Mocked<ContactsService>;
+	let blockedUsersService: jest.Mocked<BlockedUsersService>;
+
+	const OWNER_ID = 'a0000000-0000-4000-a000-000000000001';
+	const CONTACT_ID = 'b0000000-0000-4000-b000-000000000002';
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				InternalContactsService,
+				{
+					provide: ContactsService,
+					useValue: { isContact: jest.fn() },
+				},
+				{
+					provide: BlockedUsersService,
+					useValue: { isBlockedEitherWay: jest.fn() },
+				},
+			],
+		}).compile();
+
+		service = module.get(InternalContactsService);
+		contactsService = module.get(ContactsService);
+		blockedUsersService = module.get(BlockedUsersService);
+	});
+
+	describe('checkContactRelation', () => {
+		it('returns isContact:true and isBlocked:false when the relation exists and no block', async () => {
+			contactsService.isContact.mockResolvedValue(true);
+			blockedUsersService.isBlockedEitherWay.mockResolvedValue(false);
+
+			const result = await service.checkContactRelation(OWNER_ID, CONTACT_ID);
+
+			expect(result).toEqual({ isContact: true, isBlocked: false });
+			expect(contactsService.isContact).toHaveBeenCalledWith(OWNER_ID, CONTACT_ID);
+			expect(blockedUsersService.isBlockedEitherWay).toHaveBeenCalledWith(OWNER_ID, CONTACT_ID);
+		});
+
+		it('returns isContact:false when no contact row exists (still 200)', async () => {
+			contactsService.isContact.mockResolvedValue(false);
+			blockedUsersService.isBlockedEitherWay.mockResolvedValue(false);
+
+			const result = await service.checkContactRelation(OWNER_ID, CONTACT_ID);
+
+			expect(result).toEqual({ isContact: false, isBlocked: false });
+		});
+
+		it('reports isBlocked:true when a block exists in either direction', async () => {
+			contactsService.isContact.mockResolvedValue(true);
+			blockedUsersService.isBlockedEitherWay.mockResolvedValue(true);
+
+			const result = await service.checkContactRelation(OWNER_ID, CONTACT_ID);
+
+			expect(result).toEqual({ isContact: true, isBlocked: true });
+		});
+
+		it('short-circuits when ownerId === contactId without touching repositories', async () => {
+			const result = await service.checkContactRelation(OWNER_ID, OWNER_ID);
+
+			expect(result).toEqual({ isContact: false, isBlocked: false });
+			expect(contactsService.isContact).not.toHaveBeenCalled();
+			expect(blockedUsersService.isBlockedEitherWay).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/modules/internal/contacts/internal-contacts.service.ts
+++ b/src/modules/internal/contacts/internal-contacts.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { ContactsService } from '../../contacts/services/contacts.service';
+import { BlockedUsersService } from '../../blocked-users/services/blocked-users.service';
+import { CheckContactResponseDto } from './dto/check-contact-response.dto';
+
+@Injectable()
+export class InternalContactsService {
+	constructor(
+		private readonly contactsService: ContactsService,
+		private readonly blockedUsersService: BlockedUsersService
+	) {}
+
+	async checkContactRelation(ownerId: string, contactId: string): Promise<CheckContactResponseDto> {
+		if (ownerId === contactId) {
+			return { isContact: false, isBlocked: false };
+		}
+
+		const [isContact, isBlocked] = await Promise.all([
+			this.contactsService.isContact(ownerId, contactId),
+			this.blockedUsersService.isBlockedEitherWay(ownerId, contactId),
+		]);
+
+		return { isContact, isBlocked };
+	}
+}

--- a/src/modules/internal/internal-auth.guard.spec.ts
+++ b/src/modules/internal/internal-auth.guard.spec.ts
@@ -1,0 +1,63 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InternalAuthGuard } from './internal-auth.guard';
+
+const buildContext = (headers: Record<string, string | string[] | undefined>): ExecutionContext =>
+	({
+		switchToHttp: () => ({
+			getRequest: () => ({ headers }),
+		}),
+	}) as ExecutionContext;
+
+describe('InternalAuthGuard', () => {
+	const buildGuard = (token?: string) => {
+		const configService = {
+			get: jest
+				.fn()
+				.mockImplementation((key: string) => (key === 'INTERNAL_API_TOKEN' ? token : undefined)),
+		} as unknown as ConfigService;
+		return new InternalAuthGuard(configService);
+	};
+
+	it('allows the request when the header matches the configured token', () => {
+		const guard = buildGuard('secret-token');
+		const ctx = buildContext({ 'x-internal-token': 'secret-token' });
+
+		expect(guard.canActivate(ctx)).toBe(true);
+	});
+
+	it('rejects the request when the header is missing', () => {
+		const guard = buildGuard('secret-token');
+		const ctx = buildContext({});
+
+		expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+	});
+
+	it('rejects the request when the header does not match', () => {
+		const guard = buildGuard('secret-token');
+		const ctx = buildContext({ 'x-internal-token': 'wrong-token' });
+
+		expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+	});
+
+	it('rejects when the header has a different length than the expected token', () => {
+		const guard = buildGuard('secret-token');
+		const ctx = buildContext({ 'x-internal-token': 'short' });
+
+		expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+	});
+
+	it('fails closed when INTERNAL_API_TOKEN is not configured', () => {
+		const guard = buildGuard(undefined);
+		const ctx = buildContext({ 'x-internal-token': 'anything' });
+
+		expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+	});
+
+	it('uses only the first value when the header is provided as an array', () => {
+		const guard = buildGuard('secret-token');
+		const ctx = buildContext({ 'x-internal-token': ['secret-token', 'extra'] });
+
+		expect(guard.canActivate(ctx)).toBe(true);
+	});
+});

--- a/src/modules/internal/internal-auth.guard.ts
+++ b/src/modules/internal/internal-auth.guard.ts
@@ -1,0 +1,37 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { timingSafeEqual } from 'crypto';
+import type { Request } from 'express';
+
+const INTERNAL_TOKEN_HEADER = 'x-internal-token';
+
+@Injectable()
+export class InternalAuthGuard implements CanActivate {
+	constructor(private readonly configService: ConfigService) {}
+
+	canActivate(context: ExecutionContext): boolean {
+		const expected = this.configService.get<string>('INTERNAL_API_TOKEN');
+		if (!expected) {
+			throw new UnauthorizedException('Internal API not configured');
+		}
+
+		const req = context.switchToHttp().getRequest<Request>();
+		const headerValue = req.headers[INTERNAL_TOKEN_HEADER];
+		const provided = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+		if (!provided || !this.constantTimeEqual(provided, expected)) {
+			throw new UnauthorizedException('Invalid internal token');
+		}
+
+		return true;
+	}
+
+	private constantTimeEqual(a: string, b: string): boolean {
+		const bufA = Buffer.from(a);
+		const bufB = Buffer.from(b);
+		if (bufA.length !== bufB.length) {
+			return false;
+		}
+		return timingSafeEqual(bufA, bufB);
+	}
+}

--- a/src/modules/internal/internal.module.ts
+++ b/src/modules/internal/internal.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ContactsModule } from '../contacts/contacts.module';
+import { BlockedUsersModule } from '../blocked-users/blocked-users.module';
+import { InternalAuthGuard } from './internal-auth.guard';
+import { InternalContactsController } from './contacts/internal-contacts.controller';
+import { InternalContactsService } from './contacts/internal-contacts.service';
+
+@Module({
+	imports: [ContactsModule, BlockedUsersModule],
+	controllers: [InternalContactsController],
+	providers: [InternalAuthGuard, InternalContactsService],
+})
+export class InternalModule {}

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -10,6 +10,15 @@ function buildSwaggerDocument() {
 		.setVersion('1.0')
 		.addServer('/', 'Current host')
 		.addBearerAuth()
+		.addApiKey(
+			{
+				type: 'apiKey',
+				name: 'x-internal-token',
+				in: 'header',
+				description: 'Shared secret for service-to-service calls under /internal/v1/...',
+			},
+			'internal-token'
+		)
 		.build();
 }
 

--- a/test/functional.e2e-spec.ts
+++ b/test/functional.e2e-spec.ts
@@ -1,6 +1,6 @@
 import * as jwt from 'jsonwebtoken';
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe, VersioningType } from '@nestjs/common';
+import { INestApplication, RequestMethod, ValidationPipe, VersioningType } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { AppModule } from '../src/modules/app.module';
@@ -14,6 +14,7 @@ const request = require('supertest');
 const JWT_SECRET = 'test-e2e-secret';
 const JWT_ISSUER = 'test-issuer';
 const JWT_AUDIENCE = 'test-audience';
+const INTERNAL_TOKEN = 'test-internal-token';
 const USER_A_ID = 'a0000000-0000-4000-a000-000000000001';
 const USER_B_ID = 'b0000000-0000-4000-b000-000000000002';
 
@@ -46,6 +47,7 @@ describe('Functional E2E Scenarios', () => {
 	let dataSource: DataSource;
 
 	beforeAll(async () => {
+		process.env.INTERNAL_API_TOKEN = INTERNAL_TOKEN;
 		const moduleFixture: TestingModule = await Test.createTestingModule({
 			imports: [AppModule],
 		})
@@ -62,7 +64,9 @@ describe('Functional E2E Scenarios', () => {
 			.compile();
 
 		app = moduleFixture.createNestApplication();
-		app.setGlobalPrefix('user');
+		app.setGlobalPrefix('user', {
+			exclude: [{ path: 'internal/(.*)', method: RequestMethod.ALL }],
+		});
 		app.enableVersioning({
 			type: VersioningType.URI,
 			defaultVersion: '1',
@@ -274,6 +278,60 @@ describe('Functional E2E Scenarios', () => {
 				.expect(200);
 
 			expect(verifyRes.body.searchByPhone).toBe(false);
+		});
+	});
+
+	// Scenario 6: Internal contact-check endpoint (machine-to-machine)
+	describe('Scenario 6: Internal /internal/v1/contacts/check (M2M)', () => {
+		const internalHeader = { 'x-internal-token': INTERNAL_TOKEN };
+
+		it('returns isContact:true and isBlocked:false for an existing contact relationship', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+			await createUser(USER_B_ID, '+33600000002', 'bob');
+
+			// Establish the contact relationship through the public flow
+			const sendRes = await request(app.getHttpServer())
+				.post('/user/v1/contact-requests')
+				.set(asUser(USER_A_ID))
+				.send({ contactId: USER_B_ID })
+				.expect(201);
+
+			await request(app.getHttpServer())
+				.patch(`/user/v1/contact-requests/${sendRes.body.id}/accept`)
+				.set(asUser(USER_B_ID))
+				.expect(200);
+
+			const res = await request(app.getHttpServer())
+				.get(`/internal/v1/contacts/check?ownerId=${USER_A_ID}&contactId=${USER_B_ID}`)
+				.set(internalHeader)
+				.expect(200);
+
+			expect(res.body).toEqual({ isContact: true, isBlocked: false });
+		});
+
+		it('returns 200 with isContact:false when no contact row exists', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+			await createUser(USER_B_ID, '+33600000002', 'bob');
+
+			const res = await request(app.getHttpServer())
+				.get(`/internal/v1/contacts/check?ownerId=${USER_A_ID}&contactId=${USER_B_ID}`)
+				.set(internalHeader)
+				.expect(200);
+
+			expect(res.body).toEqual({ isContact: false, isBlocked: false });
+		});
+
+		it('returns 401 when the internal token header is missing', async () => {
+			await request(app.getHttpServer())
+				.get(`/internal/v1/contacts/check?ownerId=${USER_A_ID}&contactId=${USER_B_ID}`)
+				.expect(401);
+		});
+
+		it('returns 400 when ownerId is not a UUID', async () => {
+			await request(app.getHttpServer())
+				.get(`/internal/v1/contacts/check?ownerId=not-a-uuid&contactId=${USER_B_ID}`)
+				.set(internalHeader)
+				.expect(400);
 		});
 	});
 });

--- a/test/functional.e2e-spec.ts
+++ b/test/functional.e2e-spec.ts
@@ -45,8 +45,10 @@ class TestJwtStrategy extends PassportStrategy(Strategy) {
 describe('Functional E2E Scenarios', () => {
 	let app: INestApplication;
 	let dataSource: DataSource;
+	let previousInternalToken: string | undefined;
 
 	beforeAll(async () => {
+		previousInternalToken = process.env.INTERNAL_API_TOKEN;
 		process.env.INTERNAL_API_TOKEN = INTERNAL_TOKEN;
 		const moduleFixture: TestingModule = await Test.createTestingModule({
 			imports: [AppModule],
@@ -86,6 +88,11 @@ describe('Functional E2E Scenarios', () => {
 
 	afterAll(async () => {
 		if (app) await app.close();
+		if (previousInternalToken === undefined) {
+			delete process.env.INTERNAL_API_TOKEN;
+		} else {
+			process.env.INTERNAL_API_TOKEN = previousInternalToken;
+		}
 	});
 
 	beforeEach(async () => {


### PR DESCRIPTION
## Summary

- Adds a machine-to-machine endpoint `GET /internal/v1/contacts/check?ownerId=...&contactId=...` returning `{ isContact, isBlocked }`. The route is excluded from the global `user` prefix and gated by an `x-internal-token` shared secret, so it is not reachable through the public API gateway.
- Replaces the O(n) paginated scan that `messaging-service` currently performs to authorise direct conversations. The check now boils down to two indexed lookups (`SELECT 1` on `users.contacts` + a single `users.blocked_users` query covering both directions).
- Adds `INTERNAL_API_TOKEN` to the required env var check; the guard fails closed when the variable is missing.

## Test plan

- [x] Unit tests green (`npx jest --no-coverage`) — 792 passing
- [x] E2E tests green (`npm run test:e2e:docker`) — including 4 new scenarios on the internal endpoint (200 with isContact:true, 200 with isContact:false, 401 without token, 400 on invalid UUID)
- [x] Lint clean (`npx eslint`, `npx prettier --write`)
- [x] OpenAPI doc updated (`internal-token` apiKey scheme registered in `swagger.ts`)

Closes WHISPR-1229
