### PR TITLE
[WHISPR-1233] fix(search): wrap username and phone search responses in { user } envelope

### DIFF
--- a/documentation/INTEGRATION.md
+++ b/documentation/INTEGRATION.md
@@ -326,16 +326,20 @@ export const searchService = {
     return response.data;
   },
 
-  // Recherche par téléphone
+  // Recherche par téléphone — la réponse est toujours un objet { user: User | null }
   async searchByPhone(phoneNumber) {
-    const response = await apiClient.get(`/search/phone/${encodeURIComponent(phoneNumber)}`);
-    return response.data;
+    const response = await apiClient.get(
+      `/search/phone?phoneNumber=${encodeURIComponent(phoneNumber)}`
+    );
+    return response.data.user;
   },
 
-  // Recherche par nom d'utilisateur
+  // Recherche par nom d'utilisateur — la réponse est toujours un objet { user: User | null }
   async searchByUsername(username) {
-    const response = await apiClient.get(`/search/username/${username}`);
-    return response.data;
+    const response = await apiClient.get(
+      `/search/username?username=${encodeURIComponent(username)}`
+    );
+    return response.data.user;
   },
 };
 ```

--- a/src/modules/search/controllers/user-search.controller.spec.ts
+++ b/src/modules/search/controllers/user-search.controller.spec.ts
@@ -29,14 +29,22 @@ describe('UserSearchController', () => {
 	});
 
 	describe('searchByPhone', () => {
-		it('delegates to the service', async () => {
+		it('wraps the matched user in a { user } envelope', async () => {
 			const user = { id: 'u1' } as User;
 			service.searchByPhone.mockResolvedValue(user);
 
 			const result = await controller.searchByPhone({ phoneNumber: '+33600000000' });
 
-			expect(result).toBe(user);
+			expect(result).toEqual({ user });
 			expect(service.searchByPhone).toHaveBeenCalledWith('+33600000000');
+		});
+
+		it('returns { user: null } when no user matches', async () => {
+			service.searchByPhone.mockResolvedValue(null);
+
+			const result = await controller.searchByPhone({ phoneNumber: '+33600000000' });
+
+			expect(result).toEqual({ user: null });
 		});
 	});
 
@@ -54,14 +62,22 @@ describe('UserSearchController', () => {
 	});
 
 	describe('searchByUsername', () => {
-		it('delegates to the service', async () => {
+		it('wraps the matched user in a { user } envelope', async () => {
 			const user = { id: 'u1' } as User;
 			service.searchByUsername.mockResolvedValue(user);
 
 			const result = await controller.searchByUsername({ username: 'alice' });
 
-			expect(result).toBe(user);
+			expect(result).toEqual({ user });
 			expect(service.searchByUsername).toHaveBeenCalledWith('alice');
+		});
+
+		it('returns { user: null } when no user matches', async () => {
+			service.searchByUsername.mockResolvedValue(null);
+
+			const result = await controller.searchByUsername({ username: 'alice' });
+
+			expect(result).toEqual({ user: null });
 		});
 	});
 

--- a/src/modules/search/controllers/user-search.controller.ts
+++ b/src/modules/search/controllers/user-search.controller.ts
@@ -7,6 +7,7 @@ import { BatchPhoneSearchDto } from '../dto/batch-phone-search.dto';
 import { PhoneSearchQueryDto } from '../dto/phone-search-query.dto';
 import { NameSearchQueryDto } from '../dto/name-search-query.dto';
 import { UsernameSearchQueryDto } from '../dto/username-search-query.dto';
+import { UserSearchResponseDto } from '../dto/user-search-response.dto';
 
 const SEARCH_THROTTLE_TTL_MS = 60_000;
 const SEARCH_THROTTLE_LIMIT = 20;
@@ -21,10 +22,14 @@ export class UserSearchController {
 	@Get('phone')
 	@ApiOperation({ summary: 'Search user by phone number' })
 	@ApiQuery({ name: 'phoneNumber', type: 'string', description: 'E.164 phone number' })
-	@ApiResponse({ status: HttpStatus.OK, description: 'User found or null' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Envelope { user } — user is null when no match',
+		type: UserSearchResponseDto,
+	})
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async searchByPhone(@Query() dto: PhoneSearchQueryDto): Promise<User | null> {
-		return this.userSearchService.searchByPhone(dto.phoneNumber);
+	async searchByPhone(@Query() dto: PhoneSearchQueryDto): Promise<UserSearchResponseDto> {
+		return { user: await this.userSearchService.searchByPhone(dto.phoneNumber) };
 	}
 
 	@Post('phone/batch')
@@ -38,11 +43,15 @@ export class UserSearchController {
 	@Get('username')
 	@ApiOperation({ summary: 'Search user by username' })
 	@ApiQuery({ name: 'username', type: 'string', description: 'Username (1-64 chars)' })
-	@ApiResponse({ status: HttpStatus.OK, description: 'User found or null' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Envelope { user } — user is null when no match',
+		type: UserSearchResponseDto,
+	})
 	@ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid or missing username' })
 	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
-	async searchByUsername(@Query() dto: UsernameSearchQueryDto): Promise<User | null> {
-		return this.userSearchService.searchByUsername(dto.username);
+	async searchByUsername(@Query() dto: UsernameSearchQueryDto): Promise<UserSearchResponseDto> {
+		return { user: await this.userSearchService.searchByUsername(dto.username) };
 	}
 
 	@Get('name')

--- a/src/modules/search/dto/user-search-response.dto.ts
+++ b/src/modules/search/dto/user-search-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from '../../common/entities/user.entity';
+
+export class UserSearchResponseDto {
+	@ApiProperty({
+		type: () => User,
+		nullable: true,
+		description: 'Matched user, or null when no user matches the query',
+	})
+	user!: User | null;
+}

--- a/test/functional.e2e-spec.ts
+++ b/test/functional.e2e-spec.ts
@@ -341,4 +341,47 @@ describe('Functional E2E Scenarios', () => {
 				.expect(400);
 		});
 	});
+
+	// Scenario 7: Search endpoints return a JSON envelope { user } even when no user matches
+	describe('Scenario 7: GET /search/{username,phone} envelope response', () => {
+		it('returns { user: null } as valid JSON when no username matches', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+
+			const res = await request(app.getHttpServer())
+				.get('/user/v1/search/username?username=does-not-exist')
+				.set(asUser(USER_A_ID))
+				.expect(200)
+				.expect('Content-Type', /application\/json/);
+
+			expect(res.body).toEqual({ user: null });
+			expect(res.text.length).toBeGreaterThan(0);
+		});
+
+		it('returns { user: null } as valid JSON when no phone number matches', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+
+			const res = await request(app.getHttpServer())
+				.get('/user/v1/search/phone?phoneNumber=%2B33699999999')
+				.set(asUser(USER_A_ID))
+				.expect(200)
+				.expect('Content-Type', /application\/json/);
+
+			expect(res.body).toEqual({ user: null });
+			expect(res.text.length).toBeGreaterThan(0);
+		});
+
+		it('wraps the matched user in { user } when username search succeeds', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+			await createUser(USER_B_ID, '+33600000002', 'bob');
+
+			const res = await request(app.getHttpServer())
+				.get('/user/v1/search/username?username=bob')
+				.set(asUser(USER_A_ID))
+				.expect(200);
+
+			expect(res.body.user).toBeDefined();
+			expect(res.body.user.id).toBe(USER_B_ID);
+			expect(res.body.user.username).toBe('bob');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

`GET /search/username` et `GET /search/phone` retournaient un type `User | null`. Quand le service renvoie `null` (utilisateur introuvable ou privacy bloqué via `searchByUsername`/`searchByPhone`), NestJS sérialisait la réponse en **body vide** avec `200 OK`. Côté client, `response.json()` levait `Unexpected end of input` → la recherche échouait silencieusement.

Cette PR wrappe les deux réponses dans une enveloppe `{ user: User | null }` pour que le body soit toujours du JSON valide, peu importe l'issue de la recherche.

- `GET /search/username?username=…` → `200 OK` `{ "user": { ... } }` ou `{ "user": null }`
- `GET /search/phone?phoneNumber=…` → idem
- `GET /search/name` reste inchangé (renvoyait déjà `[]`, pas concerné).

## Why not 404?

Renvoyer `404` confondrait "utilisateur n'existe pas" et "utilisateur a désactivé la recherche par username/phone dans ses paramètres privacy" — fuite d'information privacy → existence. L'enveloppe préserve l'opacité.

## ⚠️ Breaking change

Les clients existants doivent passer de `response.data` à `response.data.user`. À coordonner avec l'équipe mobile-app avant déploiement preprod.

`documentation/INTEGRATION.md` est mis à jour avec le nouveau format (et corrige aussi au passage l'URL — la doc utilisait des path params alors que le controller utilise des query params).

## Test plan

- [x] `user-search.controller.spec.ts` : 4 cas (match + null) pour `searchByPhone` et `searchByUsername`
- [x] `functional.e2e-spec.ts` Scenario 7 : 3 tests E2E vérifiant `200 OK` + body `{ user: null }` valide JSON + match positif
- [x] `npm test` : 794/794 unit tests verts
- [x] `npm run test:e2e:docker` : 16/16 E2E verts
- [x] `eslint --fix` propre, `prettier --write` propre

Closes WHISPR-1233