### PR TITLE
fix(profile): emit single-pipeline diff to keep user discoverable aft…

### DIFF
--- a/src/modules/cache/search-index.service.spec.ts
+++ b/src/modules/cache/search-index.service.spec.ts
@@ -160,6 +160,96 @@ describe('SearchIndexService', () => {
 		});
 	});
 
+	// WHISPR-1271 — the legacy pair `indexUser + removeUserFromIndex` would
+	// HDEL/DEL keys it had just (re)written when phone/userId/unchanged
+	// username were involved. `updateUserIndex` must only emit the commands
+	// strictly needed for the diff between `prev` and `next`.
+	describe('updateUserIndex', () => {
+		it('only re-writes the phone index and user cache when phone is unchanged', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const prev = makeUser({ firstName: 'Alice' });
+			const next = makeUser({ firstName: 'Alicia' });
+
+			await service.updateUserIndex(prev, next);
+
+			const [commands] = (mockCacheService.pipeline as jest.Mock).mock.calls[0];
+			expect(commands).toContainEqual(['hset', 'search:phone', next.phoneNumber, next.id]);
+			expect(commands.some((cmd: any[]) => cmd[0] === 'hdel' && cmd[1] === 'search:phone')).toBe(false);
+			expect(
+				commands.some((cmd: any[]) => cmd[0] === 'del' && String(cmd[1]).startsWith('user:cache:'))
+			).toBe(false);
+		});
+
+		it('emits exactly HDEL old + HSET new when username changes alice → alicia', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const prev = makeUser({ username: 'alice' });
+			const next = makeUser({ username: 'alicia' });
+
+			await service.updateUserIndex(prev, next);
+
+			const [commands] = (mockCacheService.pipeline as jest.Mock).mock.calls[0];
+			const usernameOps = commands.filter((cmd: any[]) => cmd[1] === 'search:username');
+			expect(usernameOps).toEqual([
+				['hdel', 'search:username', 'alice'],
+				['hset', 'search:username', 'alicia', next.id],
+			]);
+		});
+
+		it('does not HDEL the username index when username is unchanged', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const prev = makeUser({ username: 'alice', firstName: 'Alice' });
+			const next = makeUser({ username: 'alice', firstName: 'Alicia' });
+
+			await service.updateUserIndex(prev, next);
+
+			const [commands] = (mockCacheService.pipeline as jest.Mock).mock.calls[0];
+			expect(commands.some((cmd: any[]) => cmd[0] === 'hdel' && cmd[1] === 'search:username')).toBe(
+				false
+			);
+			// Stable HSET keeps the alice → user-1 mapping warm in the cache.
+			expect(commands).toContainEqual(['hset', 'search:username', 'alice', next.id]);
+		});
+
+		it('drops old firstName zset and adds the new one when firstName changes', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const prev = makeUser({ firstName: 'Alice', lastName: 'Smith' });
+			const next = makeUser({ firstName: 'Alicia', lastName: 'Smith' });
+
+			await service.updateUserIndex(prev, next);
+
+			const [commands] = (mockCacheService.pipeline as jest.Mock).mock.calls[0];
+			expect(commands).toContainEqual(['zrem', 'search:name:alice', next.id]);
+			expect(commands).toContainEqual([
+				'zadd',
+				'search:name:alicia',
+				next.createdAt.getTime(),
+				next.id,
+			]);
+			// lastName didn't change, so its zset is rewritten (zadd) but never removed.
+			expect(commands.some((cmd: any[]) => cmd[0] === 'zrem' && cmd[1] === 'search:name:smith')).toBe(
+				false
+			);
+		});
+
+		it('does not emit zrem for unchanged firstName/lastName/fullName', async () => {
+			mockCacheService.pipeline = jest.fn().mockResolvedValue(undefined);
+			const prev = makeUser({ firstName: 'Alice', lastName: 'Smith', username: 'alice' });
+			const next = makeUser({ firstName: 'Alice', lastName: 'Smith', username: 'alicia' });
+
+			await service.updateUserIndex(prev, next);
+
+			const [commands] = (mockCacheService.pipeline as jest.Mock).mock.calls[0];
+			const zremOps = commands.filter((cmd: any[]) => cmd[0] === 'zrem');
+			expect(zremOps).toEqual([]);
+		});
+
+		it('throws when pipeline fails', async () => {
+			mockCacheService.pipeline = jest.fn().mockRejectedValue(new Error('Redis error'));
+
+			await expect(service.updateUserIndex(makeUser(), makeUser())).rejects.toThrow('Redis error');
+		});
+	});
+
 	describe('getCachedUser', () => {
 		it('should return cached user entry', async () => {
 			const entry = { userId: 'user-1', phoneNumber: '+1' } as any;

--- a/src/modules/cache/search-index.service.ts
+++ b/src/modules/cache/search-index.service.ts
@@ -87,6 +87,82 @@ export class SearchIndexService {
 		}
 	}
 
+	/**
+	 * Reconcile search indexes for a profile update by emitting only the
+	 * commands needed for the actual diff between `prev` and `next`.
+	 *
+	 * The legacy `indexUser(saved)` followed by `removeUserFromIndex(prev)`
+	 * pattern would `HDEL search:phone` and `DEL user:cache:<userId>` for
+	 * keys that were just rewritten — wiping the user from the search caches
+	 * after every profile edit (WHISPR-1271). This method skips deletes for
+	 * stable fields (phone, userId) and for unchanged username/name parts,
+	 * and bundles everything in a single Redis pipeline.
+	 */
+	async updateUserIndex(prev: User, next: User): Promise<void> {
+		try {
+			const indexEntry: SearchIndexEntry = {
+				userId: next.id,
+				phoneNumber: next.phoneNumber,
+				username: next.username ?? null,
+				firstName: next.firstName ?? null,
+				lastName: next.lastName ?? null,
+				fullName: this.buildFullName(next),
+				isActive: next.isActive,
+				createdAt: next.createdAt,
+			};
+
+			const commands: Array<[string, ...any[]]> = [
+				// Phone is immutable for a profile edit and userId never changes;
+				// HSET / SETEX overwrite any existing value, no HDEL/DEL needed.
+				['hset', this.PHONE_INDEX_KEY, next.phoneNumber, next.id],
+				['setex', `${this.USER_CACHE_PREFIX}:${next.id}`, this.CACHE_TTL, JSON.stringify(indexEntry)],
+			];
+
+			const prevUsername = prev.username?.toLowerCase();
+			const nextUsername = next.username?.toLowerCase();
+			if (prevUsername && prevUsername !== nextUsername) {
+				commands.push(['hdel', this.USERNAME_INDEX_KEY, prevUsername]);
+			}
+			if (nextUsername) {
+				commands.push(['hset', this.USERNAME_INDEX_KEY, nextUsername, next.id]);
+			}
+
+			this.appendNameDiff(commands, prev.firstName, next.firstName, next);
+			this.appendNameDiff(commands, prev.lastName, next.lastName, next);
+			this.appendNameDiff(commands, this.buildFullName(prev), this.buildFullName(next), next);
+
+			await this.cacheService.pipeline(commands);
+			this.logger.debug(`Updated search indexes for user ${next.id}`);
+		} catch (error) {
+			this.logger.error(`Failed to update search indexes for user ${next.id}:`, error);
+			throw error;
+		}
+	}
+
+	private buildFullName(user: Pick<User, 'firstName' | 'lastName'>): string {
+		return [user.firstName, user.lastName]
+			.filter((p): p is string => !!p)
+			.join(' ')
+			.toLowerCase()
+			.trim();
+	}
+
+	private appendNameDiff(
+		commands: Array<[string, ...any[]]>,
+		prevValue: string | null | undefined,
+		nextValue: string | null | undefined,
+		next: User
+	): void {
+		const prevNorm = prevValue?.toLowerCase();
+		const nextNorm = nextValue?.toLowerCase();
+		if (prevNorm && prevNorm !== nextNorm) {
+			commands.push(['zrem', `${this.NAME_INDEX_KEY}:${prevNorm}`, next.id]);
+		}
+		if (nextNorm) {
+			commands.push(['zadd', `${this.NAME_INDEX_KEY}:${nextNorm}`, next.createdAt.getTime(), next.id]);
+		}
+	}
+
 	async removeUserFromIndex(user: User): Promise<void> {
 		try {
 			const normalizedUsername = user.username?.toLowerCase();

--- a/src/modules/profile/services/profile.service.spec.ts
+++ b/src/modules/profile/services/profile.service.spec.ts
@@ -55,7 +55,11 @@ describe('ProfileService', () => {
 	let service: ProfileService;
 	let userRepository: jest.Mocked<UserRepository>;
 	let mediaClient: jest.Mocked<MediaClientService>;
-	let searchIndexService: { indexUser: jest.Mock; removeUserFromIndex: jest.Mock };
+	let searchIndexService: {
+		indexUser: jest.Mock;
+		removeUserFromIndex: jest.Mock;
+		updateUserIndex: jest.Mock;
+	};
 	let privacyService: { getSettings: jest.Mock };
 	let contactsService: { isContact: jest.Mock };
 
@@ -93,6 +97,7 @@ describe('ProfileService', () => {
 					useValue: {
 						indexUser: jest.fn().mockResolvedValue(undefined),
 						removeUserFromIndex: jest.fn().mockResolvedValue(undefined),
+						updateUserIndex: jest.fn().mockResolvedValue(undefined),
 					},
 				},
 				{
@@ -218,7 +223,7 @@ describe('ProfileService', () => {
 			expect(userRepository.findByUsernameInsensitive).not.toHaveBeenCalled();
 		});
 
-		it('indexes user in search when username is updated', async () => {
+		it('reconciles search indexes via updateUserIndex when a username is set', async () => {
 			const user = mockUser();
 			const dto: UpdateProfileDto = { username: 'alice' };
 			const saved = { ...user, username: 'alice' } as User;
@@ -229,10 +234,13 @@ describe('ProfileService', () => {
 
 			await service.updateProfile('uuid-1', dto);
 
-			expect(searchIndexService.indexUser).toHaveBeenCalledWith(saved);
+			expect(searchIndexService.updateUserIndex).toHaveBeenCalledWith(
+				expect.objectContaining({ id: user.id, username: null }),
+				saved
+			);
 		});
 
-		it('removes old index entries when username changes', async () => {
+		it('passes both prev and next snapshots when username changes', async () => {
 			const user = { ...mockUser(), username: 'old-name' } as User;
 			const dto: UpdateProfileDto = { username: 'new-name' };
 			const saved = { ...user, username: 'new-name' } as User;
@@ -243,9 +251,49 @@ describe('ProfileService', () => {
 
 			await service.updateProfile('uuid-1', dto);
 
-			expect(searchIndexService.removeUserFromIndex).toHaveBeenCalledWith(
-				expect.objectContaining({ username: 'old-name' })
+			expect(searchIndexService.updateUserIndex).toHaveBeenCalledWith(
+				expect.objectContaining({ username: 'old-name' }),
+				expect.objectContaining({ username: 'new-name' })
 			);
+		});
+
+		// WHISPR-1271 — the legacy indexUser+removeUserFromIndex pair would
+		// HDEL/DEL keys it had just rewritten when only firstName changed.
+		// The fix routes through updateUserIndex; the legacy pair must never fire.
+		it('does not call legacy indexUser/removeUserFromIndex when only firstName changes', async () => {
+			const user = { ...mockUser(), firstName: 'Alice' } as User;
+			const dto: UpdateProfileDto = { firstName: 'Alicia' };
+			const saved = { ...user, firstName: 'Alicia' } as User;
+
+			userRepository.findById.mockResolvedValue(user);
+			userRepository.save.mockResolvedValue(saved);
+
+			await service.updateProfile('uuid-1', dto);
+
+			expect(searchIndexService.indexUser).not.toHaveBeenCalled();
+			expect(searchIndexService.removeUserFromIndex).not.toHaveBeenCalled();
+			expect(searchIndexService.updateUserIndex).toHaveBeenCalledWith(
+				expect.objectContaining({ firstName: 'Alice' }),
+				expect.objectContaining({ firstName: 'Alicia' })
+			);
+		});
+
+		// WHISPR-1271 — guard against re-introducing an `if` that fires the
+		// reconciliation for biography-only / no-name updates (would burn a
+		// Redis pipeline for nothing and risk re-introducing the wipe bug).
+		it('does not touch search indexes when no name/username/lastName changes', async () => {
+			const user = { ...mockUser(), firstName: 'Alice', username: 'alice' } as User;
+			const dto: UpdateProfileDto = { biography: 'Hello world' };
+			const saved = { ...user, biography: 'Hello world' } as User;
+
+			userRepository.findById.mockResolvedValue(user);
+			userRepository.save.mockResolvedValue(saved);
+
+			await service.updateProfile('uuid-1', dto);
+
+			expect(searchIndexService.updateUserIndex).not.toHaveBeenCalled();
+			expect(searchIndexService.indexUser).not.toHaveBeenCalled();
+			expect(searchIndexService.removeUserFromIndex).not.toHaveBeenCalled();
 		});
 
 		it('swallows search indexing errors without failing the update', async () => {
@@ -255,7 +303,7 @@ describe('ProfileService', () => {
 
 			userRepository.findById.mockResolvedValue(user);
 			userRepository.save.mockResolvedValue(saved);
-			searchIndexService.indexUser.mockRejectedValue(new Error('Redis down'));
+			searchIndexService.updateUserIndex.mockRejectedValue(new Error('Redis down'));
 
 			const result = await service.updateProfile('uuid-1', dto);
 

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -125,10 +125,10 @@ export class ProfileService {
 			saved.lastName !== previousSnapshot.lastName
 		) {
 			try {
-				// Index new data first, then remove old entries — if indexUser fails,
-				// the user remains discoverable under the old keys instead of vanishing.
-				await this.searchIndexService.indexUser(saved);
-				await this.searchIndexService.removeUserFromIndex(previousSnapshot as User);
+				// WHISPR-1271 : single-pipeline diff. The previous
+				// `indexUser(saved) + removeUserFromIndex(prev)` pair deleted phone /
+				// user-cache / unchanged-username keys that had just been rewritten.
+				await this.searchIndexService.updateUserIndex(previousSnapshot as User, saved);
 			} catch (err) {
 				this.logger.warn(`Failed to update search index for user ${saved.id}: ${err}`);
 			}


### PR DESCRIPTION
…er profile edit (WHISPR-1271)

L'ancien flux `indexUser(saved)` puis `removeUserFromIndex(prev)` supprimait les clés Redis qu'il venait de réécrire :
- HSET search:phone <phone> ... puis HDEL search:phone <phone> (téléphone immuable)
- SETEX user:cache:<id> ... puis DEL user:cache:<id> (id immuable)
- HSET search:username <name> ... puis HDEL search:username <name> si name inchangé

Net effet : à chaque PUT /user/v1/profile (même un changement de prénom seul) l'utilisateur disparaissait des recherches par téléphone et par username, et le cache user:cache:* était vidé. Le fallback DB de la recherche masquait partiellement le bug en production.

Nouveau `SearchIndexService.updateUserIndex(prev, next)` :
- bundle tout dans un seul pipeline Redis ;
- ne re-écrit qu'une fois HSET search:phone et SETEX user:cache (pas de delete) ;
- HDEL ancien username uniquement si username a changé ;
- ZREM ancien firstName/lastName/fullName uniquement si la valeur a changé.

ProfileService.updateProfile route via cette nouvelle méthode quand username/firstName/lastName change ; le bloc reste no-op pour les éditions qui n'affectent pas la recherche (biographie, avatar). Tests :
- profile.service.spec : nouveaux cas firstName-only et biography-only qui vérifient que les anciennes méthodes ne sont jamais appelées.
- search-index.service.spec : updateUserIndex couvre phone-stable, username-change, name-change, et l'ensemble unchanged.