### PR TITLE
[WHISPR-1292] docs(profile): traduction commentaires FR + cleanup paraphrases

### DIFF
--- a/src/modules/profile/services/media-client.service.ts
+++ b/src/modules/profile/services/media-client.service.ts
@@ -2,16 +2,16 @@ import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 /**
- * Lightweight HTTP client for the media-service.
+ * Petit client HTTP pour le media-service.
  *
- * The media-service contract (MediaMetadataDto from Swagger):
- *   GET  /media/v1/:id       → { id, ownerId, context, contentType, blobSize, ... }
- *   GET  /media/v1/:id/blob  → { url, expiresAt } (presigned S3 URL)
- *   POST /media/v1/upload    → multipart upload (handled by mobile/frontend)
+ * Contrat du media-service (MediaMetadataDto cote Swagger) :
+ *   GET  /media/v1/:id       -> { id, ownerId, context, contentType, blobSize, ... }
+ *   GET  /media/v1/:id/blob  -> { url, expiresAt } (URL S3 presignee)
+ *   POST /media/v1/upload    -> upload multipart (gere par le mobile/frontend)
  *
- * This client calls GET /media/v1/:id to validate a mediaId before storing
- * the corresponding blob URL as the profile picture, and GET /media/v1/:id/blob
- * to get a presigned URL the browser can use directly in <img src>.
+ * On appelle GET /media/v1/:id pour valider un mediaId avant de stocker l'URL
+ * comme photo de profil, et GET /media/v1/:id/blob pour recuperer une URL
+ * presignee utilisable directement dans un <img src> cote navigateur.
  */
 export interface MediaMetadata {
 	id: string;
@@ -35,10 +35,10 @@ interface CachedPresignedUrl {
 	expiresAtMs: number;
 }
 
-// WHISPR-1253: keep a short in-memory cache so we don't re-presign the same
-// mediaId on every profile read. The presigned URL has a much longer TTL on
-// the media-service side (hours), but a 60s window is enough to absorb a
-// burst of conversations-list reads that touch the same avatars.
+// WHISPR-1253 : petit cache en memoire pour ne pas re-presigner le meme mediaId
+// a chaque lecture de profil. Le media-service garde l'URL presignee valide
+// plusieurs heures, mais une fenetre de 60s suffit a absorber un burst de
+// lectures de la liste de conversations qui tapent les memes avatars.
 const PRESIGN_CACHE_TTL_MS = 60 * 1000;
 const PRESIGN_CACHE_MAX_ENTRIES = 1000;
 
@@ -57,30 +57,31 @@ export class MediaClientService {
 	}
 
 	/**
-	 * Builds the legacy blob endpoint URL. Kept for backwards-compatibility
-	 * with callers that still expect a path string. NEW callers serialising
-	 * a profile picture for a browser client must use `presignProfilePictureUrl`
-	 * instead, since this endpoint requires a JWT and `<img src>` cannot
-	 * carry an Authorization header.
+	 * Construit l'URL legacy de l'endpoint blob. Conservee pour compat avec
+	 * les appelants qui attendent encore un simple path. Les NOUVEAUX appelants
+	 * qui serialisent une photo de profil pour un client navigateur doivent
+	 * passer par `presignProfilePictureUrl` : cet endpoint exige un JWT et
+	 * `<img src>` ne peut pas porter de header Authorization.
 	 */
 	resolveProfilePictureUrl(mediaId: string): string {
 		return `${this.baseUrl}/media/v1/${mediaId}/blob`;
 	}
 
 	/**
-	 * WHISPR-1253: Returns a presigned S3 URL the browser can use directly in
-	 * `<img src>` without an Authorization header.
+	 * WHISPR-1253 : renvoie une URL S3 presignee utilisable directement dans
+	 * `<img src>` sans header Authorization.
 	 *
-	 * Calls media-service GET /media/v1/:id/blob propagating the caller's JWT
-	 * so the read ACL stays enforced (avatar/group_icon are public-readable
-	 * but media-service still requires a valid JWT to issue a signed URL).
+	 * Appelle media-service GET /media/v1/:id/blob en propageant le JWT de
+	 * l'appelant pour que l'ACL en lecture reste appliquee (avatar/group_icon
+	 * sont lisibles publiquement mais le media-service exige quand meme un
+	 * JWT valide pour emettre l'URL signee).
 	 *
-	 * Falls back to the bare blob endpoint URL when:
-	 *   - no Authorization header is available (e.g. internal caller)
-	 *   - media-service is unreachable
-	 *   - media-service returns an error
-	 * The fallback path keeps the previous behaviour so a media-service outage
-	 * does not break the whole user-service profile responses.
+	 * Fallback vers l'URL brute du blob si :
+	 *   - pas de header Authorization (ex: appelant interne)
+	 *   - media-service injoignable
+	 *   - media-service renvoie une erreur
+	 * Ce fallback garde l'ancien comportement pour qu'une panne media-service
+	 * ne casse pas toutes les reponses profile du user-service.
 	 */
 	async presignProfilePictureUrl(mediaId: string, authorization?: string): Promise<string> {
 		const fallback = this.resolveProfilePictureUrl(mediaId);
@@ -138,12 +139,12 @@ export class MediaClientService {
 	}
 
 	/**
-	 * Fetch media metadata from media-service by ID.
+	 * Recupere les metadonnees d'un media depuis le media-service par son ID.
 	 *
-	 * @param mediaId  UUID of the uploaded media
-	 * @param userId   UUID of the requesting user (forwarded as x-user-id)
-	 * @param authorization Optional Authorization header from the caller ("Bearer ...")
-	 * @returns        MediaMetadata as returned by the media-service
+	 * @param mediaId  UUID du media uploade
+	 * @param userId   UUID de l'utilisateur appelant (transmis en x-user-id)
+	 * @param authorization Header Authorization optionnel ("Bearer ...")
+	 * @returns        MediaMetadata renvoyee par le media-service
 	 */
 	async getMediaMetadata(mediaId: string, userId: string, authorization?: string): Promise<MediaMetadata> {
 		const url = `${this.baseUrl}/media/v1/${mediaId}`;
@@ -192,9 +193,9 @@ export class MediaClientService {
 	}
 
 	private setCached(mediaId: string, url: string): void {
-		// Bound the cache size with a simple FIFO eviction. The hot set is
-		// small (a single conversations list rarely shows more than a few
-		// dozen avatars), so this is enough to avoid unbounded memory growth.
+		// Limite la taille du cache via une eviction FIFO simple. Le hot set est
+		// petit (une liste de conversations affiche rarement plus de quelques
+		// dizaines d'avatars), donc ca suffit a eviter de la memoire non-bornee.
 		if (this.presignCache.size >= PRESIGN_CACHE_MAX_ENTRIES) {
 			const firstKey = this.presignCache.keys().next().value;
 			if (firstKey !== undefined) {

--- a/src/modules/profile/services/profile.service.spec.ts
+++ b/src/modules/profile/services/profile.service.spec.ts
@@ -287,9 +287,10 @@ describe('ProfileService', () => {
 			);
 		});
 
-		// WHISPR-1271 — the legacy indexUser+removeUserFromIndex pair would
-		// HDEL/DEL keys it had just rewritten when only firstName changed.
-		// The fix routes through updateUserIndex; the legacy pair must never fire.
+		// WHISPR-1271 - l'ancien duo indexUser+removeUserFromIndex faisait
+		// HDEL/DEL sur des cles qu'il venait de reecrire quand seul firstName
+		// changeait. Le fix passe par updateUserIndex ; l'ancien duo ne doit
+		// plus jamais etre appele.
 		it('does not call legacy indexUser/removeUserFromIndex when only firstName changes', async () => {
 			const user = { ...mockUser(), firstName: 'Alice' } as User;
 			const dto: UpdateProfileDto = { firstName: 'Alicia' };
@@ -308,9 +309,10 @@ describe('ProfileService', () => {
 			);
 		});
 
-		// WHISPR-1271 — guard against re-introducing an `if` that fires the
-		// reconciliation for biography-only / no-name updates (would burn a
-		// Redis pipeline for nothing and risk re-introducing the wipe bug).
+		// WHISPR-1271 - garde-fou contre la reintroduction d'un `if` qui
+		// declencherait la reconciliation sur des updates biography-only /
+		// sans changement de nom (gaspille un pipeline Redis et risque de
+		// faire revenir le bug de wipe).
 		it('does not touch search indexes when no name/username/lastName changes', async () => {
 			const user = { ...mockUser(), firstName: 'Alice', username: 'alice' } as User;
 			const dto: UpdateProfileDto = { biography: 'Hello world' };

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -190,7 +190,7 @@ export class ProfileService {
 			}
 		}
 
-		// Resolve avatarMediaId → profilePictureUrl via media-service
+		// Resout avatarMediaId vers profilePictureUrl via le media-service
 		if (dto.avatarMediaId) {
 			const media = await this.mediaClient.getMediaMetadata(dto.avatarMediaId, id, authorization);
 			if (media.context !== 'avatar') {
@@ -219,7 +219,7 @@ export class ProfileService {
 			user.visualPreferences = mergedVisualPreferences;
 		}
 
-		// Remove transient/non-column fields before saving.
+		// Enleve les champs transitoires / non-colonnes avant de sauvegarder.
 		const { avatarMediaId, visualPreferences, backgroundMediaId, backgroundMediaUrl, ...fields } = dto;
 		Object.assign(user, fields);
 
@@ -233,9 +233,9 @@ export class ProfileService {
 			saved.lastName !== previousSnapshot.lastName
 		) {
 			try {
-				// WHISPR-1271 : single-pipeline diff. The previous
-				// `indexUser(saved) + removeUserFromIndex(prev)` pair deleted phone /
-				// user-cache / unchanged-username keys that had just been rewritten.
+				// WHISPR-1271 : diff en un seul pipeline. L'ancien duo
+				// `indexUser(saved) + removeUserFromIndex(prev)` supprimait les cles
+				// phone / user-cache / username inchange qu'on venait de reecrire.
 				await this.searchIndexService.updateUserIndex(previousSnapshot as User, saved);
 			} catch (err) {
 				this.logger.warn(`Failed to update search index for user ${saved.id}: ${err}`);


### PR DESCRIPTION
## Summary

- Traduction en francais des commentaires anglais dans `media-client.service.ts`, `profile.service.ts` et `profile.service.spec.ts`.
- Remplacement des em-dash `—` par des tirets courts `-`.
- Style humain et lisible, on explique le pourquoi plutot que paraphraser le code.

## Test plan

- [x] Unit tests verts (`npx jest --no-coverage` : 814/814)
- [x] E2E tests verts (pre-push hook)
- [x] Lint clean (`npx eslint`)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Aucun changement de code, uniquement des commentaires

Closes WHISPR-1292