### PR TITLE
[WHISPR-1303] feat(privacy): add internal privacy endpoint

### DIFF
--- a/src/modules/internal/internal.module.ts
+++ b/src/modules/internal/internal.module.ts
@@ -1,13 +1,24 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ContactsModule } from '../contacts/contacts.module';
 import { BlockedUsersModule } from '../blocked-users/blocked-users.module';
+import { CommonModule } from '../common/common.module';
+import { PrivacySettings } from '../privacy/entities/privacy-settings.entity';
+import { PrivacySettingsRepository } from '../privacy/repositories/privacy-settings.repository';
 import { InternalAuthGuard } from './internal-auth.guard';
 import { InternalContactsController } from './contacts/internal-contacts.controller';
 import { InternalContactsService } from './contacts/internal-contacts.service';
+import { InternalPrivacyController } from './privacy/internal-privacy.controller';
+import { InternalPrivacyService } from './privacy/internal-privacy.service';
 
 @Module({
-	imports: [ContactsModule, BlockedUsersModule],
-	controllers: [InternalContactsController],
-	providers: [InternalAuthGuard, InternalContactsService],
+	imports: [ContactsModule, BlockedUsersModule, CommonModule, TypeOrmModule.forFeature([PrivacySettings])],
+	controllers: [InternalContactsController, InternalPrivacyController],
+	providers: [
+		InternalAuthGuard,
+		InternalContactsService,
+		InternalPrivacyService,
+		PrivacySettingsRepository,
+	],
 })
 export class InternalModule {}

--- a/src/modules/internal/privacy/dto/internal-privacy-response.dto.ts
+++ b/src/modules/internal/privacy/dto/internal-privacy-response.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PrivacyLevel } from '../../../privacy/entities/privacy-settings.entity';
+
+export class InternalPrivacyResponseDto {
+	@ApiProperty({ description: 'UUID of the user the privacy settings belong to', format: 'uuid' })
+	userId: string;
+
+	@ApiProperty({ description: 'Whether read receipts are enabled' })
+	readReceipts: boolean;
+
+	@ApiProperty({
+		description: 'Audience that can see last seen timestamp',
+		enum: PrivacyLevel,
+	})
+	lastSeenPrivacy: PrivacyLevel;
+
+	@ApiProperty({
+		description: 'Audience that can see online status',
+		enum: PrivacyLevel,
+	})
+	onlineStatus: PrivacyLevel;
+}

--- a/src/modules/internal/privacy/internal-privacy.controller.spec.ts
+++ b/src/modules/internal/privacy/internal-privacy.controller.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { InternalPrivacyController } from './internal-privacy.controller';
+import { InternalPrivacyService } from './internal-privacy.service';
+import { PrivacyLevel } from '../../privacy/entities/privacy-settings.entity';
+
+describe('InternalPrivacyController', () => {
+	let controller: InternalPrivacyController;
+	let service: jest.Mocked<InternalPrivacyService>;
+
+	const USER_ID = 'a0000000-0000-4000-a000-000000000001';
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [InternalPrivacyController],
+			providers: [
+				{
+					provide: InternalPrivacyService,
+					useValue: { getPrivacyForInternal: jest.fn() },
+				},
+				{
+					provide: ConfigService,
+					useValue: { get: jest.fn().mockReturnValue('test-token') },
+				},
+			],
+		}).compile();
+
+		controller = module.get(InternalPrivacyController);
+		service = module.get(InternalPrivacyService);
+	});
+
+	describe('getPrivacy', () => {
+		it('delegates to the service and returns the response payload', async () => {
+			service.getPrivacyForInternal.mockResolvedValue({
+				userId: USER_ID,
+				readReceipts: true,
+				lastSeenPrivacy: PrivacyLevel.CONTACTS,
+				onlineStatus: PrivacyLevel.EVERYONE,
+			});
+
+			const result = await controller.getPrivacy(USER_ID);
+
+			expect(service.getPrivacyForInternal).toHaveBeenCalledWith(USER_ID);
+			expect(result).toEqual({
+				userId: USER_ID,
+				readReceipts: true,
+				lastSeenPrivacy: PrivacyLevel.CONTACTS,
+				onlineStatus: PrivacyLevel.EVERYONE,
+			});
+		});
+	});
+});

--- a/src/modules/internal/privacy/internal-privacy.controller.ts
+++ b/src/modules/internal/privacy/internal-privacy.controller.ts
@@ -1,0 +1,42 @@
+import {
+	Controller,
+	Get,
+	HttpStatus,
+	Param,
+	ParseUUIDPipe,
+	UseGuards,
+	VERSION_NEUTRAL,
+} from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { Public } from '../../jwt-auth/public.decorator';
+import { InternalAuthGuard } from '../internal-auth.guard';
+import { InternalPrivacyService } from './internal-privacy.service';
+import { InternalPrivacyResponseDto } from './dto/internal-privacy-response.dto';
+
+@ApiTags('Internal')
+@ApiSecurity('internal-token')
+@Public()
+@UseGuards(InternalAuthGuard)
+@Controller({ path: 'internal/v1/users', version: VERSION_NEUTRAL })
+export class InternalPrivacyController {
+	constructor(private readonly internalPrivacyService: InternalPrivacyService) {}
+
+	@Get(':id/privacy')
+	@ApiOperation({
+		summary: 'Get privacy settings of a user (machine-to-machine)',
+		description:
+			'Internal endpoint consumed by other Whispr services (e.g. messaging-service) to gate broadcasts depending on the user privacy preferences (read_receipts, last_seen_privacy, online_status). Not exposed by the public API gateway.',
+	})
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Privacy settings retrieved successfully',
+		type: InternalPrivacyResponseDto,
+	})
+	@ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'id is not a UUID' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid internal token' })
+	@ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User not found' })
+	async getPrivacy(@Param('id', ParseUUIDPipe) id: string): Promise<InternalPrivacyResponseDto> {
+		return this.internalPrivacyService.getPrivacyForInternal(id);
+	}
+}

--- a/src/modules/internal/privacy/internal-privacy.service.spec.ts
+++ b/src/modules/internal/privacy/internal-privacy.service.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { InternalPrivacyService } from './internal-privacy.service';
+import { UserRepository } from '../../common/repositories';
+import { PrivacySettingsRepository } from '../../privacy/repositories/privacy-settings.repository';
+import { PrivacyLevel, PrivacySettings } from '../../privacy/entities/privacy-settings.entity';
+
+describe('InternalPrivacyService', () => {
+	let service: InternalPrivacyService;
+	let userRepository: jest.Mocked<UserRepository>;
+	let privacySettingsRepository: jest.Mocked<PrivacySettingsRepository>;
+
+	const USER_ID = 'a0000000-0000-4000-a000-000000000001';
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				InternalPrivacyService,
+				{
+					provide: UserRepository,
+					useValue: { findById: jest.fn() },
+				},
+				{
+					provide: PrivacySettingsRepository,
+					useValue: { findByUserId: jest.fn() },
+				},
+			],
+		}).compile();
+
+		service = module.get(InternalPrivacyService);
+		userRepository = module.get(UserRepository);
+		privacySettingsRepository = module.get(PrivacySettingsRepository);
+	});
+
+	describe('getPrivacyForInternal', () => {
+		it('throws NotFoundException when the user does not exist', async () => {
+			userRepository.findById.mockResolvedValue(null);
+
+			await expect(service.getPrivacyForInternal(USER_ID)).rejects.toBeInstanceOf(NotFoundException);
+			expect(privacySettingsRepository.findByUserId).not.toHaveBeenCalled();
+		});
+
+		it('returns defaults without persisting when settings row is missing', async () => {
+			userRepository.findById.mockResolvedValue({ id: USER_ID } as never);
+			privacySettingsRepository.findByUserId.mockResolvedValue(null);
+
+			const result = await service.getPrivacyForInternal(USER_ID);
+
+			expect(result).toEqual({
+				userId: USER_ID,
+				readReceipts: true,
+				lastSeenPrivacy: PrivacyLevel.CONTACTS,
+				onlineStatus: PrivacyLevel.CONTACTS,
+			});
+		});
+
+		it('returns the stored privacy settings projected to the internal DTO shape', async () => {
+			userRepository.findById.mockResolvedValue({ id: USER_ID } as never);
+			const settings = {
+				userId: USER_ID,
+				readReceipts: false,
+				lastSeenPrivacy: PrivacyLevel.NOBODY,
+				onlineStatus: PrivacyLevel.EVERYONE,
+			} as PrivacySettings;
+			privacySettingsRepository.findByUserId.mockResolvedValue(settings);
+
+			const result = await service.getPrivacyForInternal(USER_ID);
+
+			expect(result).toEqual({
+				userId: USER_ID,
+				readReceipts: false,
+				lastSeenPrivacy: PrivacyLevel.NOBODY,
+				onlineStatus: PrivacyLevel.EVERYONE,
+			});
+		});
+	});
+});

--- a/src/modules/internal/privacy/internal-privacy.service.ts
+++ b/src/modules/internal/privacy/internal-privacy.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { UserRepository } from '../../common/repositories';
+import { PrivacySettingsRepository } from '../../privacy/repositories/privacy-settings.repository';
+import { PrivacyLevel } from '../../privacy/entities/privacy-settings.entity';
+import { InternalPrivacyResponseDto } from './dto/internal-privacy-response.dto';
+
+@Injectable()
+export class InternalPrivacyService {
+	constructor(
+		private readonly userRepository: UserRepository,
+		private readonly privacySettingsRepository: PrivacySettingsRepository
+	) {}
+
+	async getPrivacyForInternal(userId: string): Promise<InternalPrivacyResponseDto> {
+		const user = await this.userRepository.findById(userId);
+		if (!user) {
+			throw new NotFoundException('User not found');
+		}
+
+		const settings = await this.privacySettingsRepository.findByUserId(userId);
+
+		// pas de row -> renvoyer les defaults sans persister (lecture seule pour M2M)
+		if (!settings) {
+			return {
+				userId,
+				readReceipts: true,
+				lastSeenPrivacy: PrivacyLevel.CONTACTS,
+				onlineStatus: PrivacyLevel.CONTACTS,
+			};
+		}
+
+		return {
+			userId: settings.userId,
+			readReceipts: settings.readReceipts,
+			lastSeenPrivacy: settings.lastSeenPrivacy,
+			onlineStatus: settings.onlineStatus,
+		};
+	}
+}

--- a/test/functional.e2e-spec.ts
+++ b/test/functional.e2e-spec.ts
@@ -342,6 +342,66 @@ describe('Functional E2E Scenarios', () => {
 		});
 	});
 
+	// Scenario 6b: Internal privacy lookup endpoint (machine-to-machine)
+	describe('Scenario 6b: Internal /internal/v1/users/:id/privacy (M2M)', () => {
+		const internalHeader = { 'x-internal-token': INTERNAL_TOKEN };
+
+		it('returns the privacy DTO with defaults when no settings row was created yet', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+
+			const res = await request(app.getHttpServer())
+				.get(`/internal/v1/users/${USER_A_ID}/privacy`)
+				.set(internalHeader)
+				.expect(200);
+
+			expect(res.body).toEqual({
+				userId: USER_A_ID,
+				readReceipts: true,
+				lastSeenPrivacy: 'contacts',
+				onlineStatus: 'contacts',
+			});
+		});
+
+		it('reflects the user-updated privacy settings', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+
+			await request(app.getHttpServer())
+				.patch('/user/v1/privacy')
+				.set(asUser(USER_A_ID))
+				.send({ readReceipts: false, onlineStatus: 'nobody' })
+				.expect(200);
+
+			const res = await request(app.getHttpServer())
+				.get(`/internal/v1/users/${USER_A_ID}/privacy`)
+				.set(internalHeader)
+				.expect(200);
+
+			expect(res.body.userId).toBe(USER_A_ID);
+			expect(res.body.readReceipts).toBe(false);
+			expect(res.body.onlineStatus).toBe('nobody');
+		});
+
+		it('returns 401 when the internal token header is missing', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+
+			await request(app.getHttpServer()).get(`/internal/v1/users/${USER_A_ID}/privacy`).expect(401);
+		});
+
+		it('returns 404 when the user does not exist', async () => {
+			await request(app.getHttpServer())
+				.get(`/internal/v1/users/${USER_A_ID}/privacy`)
+				.set(internalHeader)
+				.expect(404);
+		});
+
+		it('returns 400 when the id is not a UUID', async () => {
+			await request(app.getHttpServer())
+				.get(`/internal/v1/users/not-a-uuid/privacy`)
+				.set(internalHeader)
+				.expect(400);
+		});
+	});
+
 	// Scenario 7: Search endpoints return a JSON envelope { user } even when no user matches
 	describe('Scenario 7: GET /search/{username,phone} envelope response', () => {
 		it('returns { user: null } as valid JSON when no username matches', async () => {


### PR DESCRIPTION
## Summary
- nouveau endpoint M2M `GET /internal/v1/users/:id/privacy` pour permettre a messaging-service de gate les broadcasts `message_read` selon `read_receipts`
- auth via header `x-internal-token` (pattern existant deja utilise par `/internal/v1/contacts/check`)
- DTO compact: `userId`, `readReceipts`, `lastSeenPrivacy`, `onlineStatus` (les autres champs prive restent prive du module privacy)

## Notes
- 404 si user inexistant; defaults retournes (sans persister) si la row `privacy_settings` n existe pas encore
- `ParseUUIDPipe` sur le param pour 400 sur input invalide
- Cache 60s prevu cote messaging-service (ETS), pas necessaire ici

## Test plan
- [x] Unit tests (controller + service mock-based) verts
- [x] E2E scenario 6b: defaults / patched-then-read / 401 / 404 / 400
- [x] Lint + prettier clean
- [x] tsc --noEmit clean

Closes WHISPR-1303