### PR TITLE
perf(db): add missing indexes on blocked_users, groups, appeals, sanctions

### DIFF
--- a/src/modules/appeals/entities/appeal.entity.ts
+++ b/src/modules/appeals/entities/appeal.entity.ts
@@ -6,6 +6,7 @@ import {
 	UpdateDateColumn,
 	ManyToOne,
 	JoinColumn,
+	Index,
 } from 'typeorm';
 import { User } from '../../common/entities/user.entity';
 import { UserSanction } from '../../sanctions/entities/user-sanction.entity';
@@ -13,6 +14,9 @@ import { UserSanction } from '../../sanctions/entities/user-sanction.entity';
 export type AppealType = 'sanction' | 'blocked_image';
 
 @Entity({ name: 'appeals', schema: 'users' })
+@Index('IDX_appeals_user_id', ['userId'])
+@Index('IDX_appeals_status', ['status'])
+@Index('IDX_appeals_user_id_status', ['userId', 'status'])
 export class Appeal {
 	@PrimaryGeneratedColumn('uuid')
 	id: string;

--- a/src/modules/blocked-users/entities/blocked-user.entity.ts
+++ b/src/modules/blocked-users/entities/blocked-user.entity.ts
@@ -6,11 +6,14 @@ import {
 	ManyToOne,
 	JoinColumn,
 	Unique,
+	Index,
 } from 'typeorm';
 import { User } from '../../common/entities/user.entity';
 
 @Entity({ name: 'blocked_users', schema: 'users' })
 @Unique(['blockerId', 'blockedId'])
+@Index('IDX_blocked_users_blocker_id', ['blockerId'])
+@Index('IDX_blocked_users_blocked_id', ['blockedId'])
 export class BlockedUser {
 	@PrimaryGeneratedColumn('uuid')
 	id: string;

--- a/src/modules/groups/entities/group.entity.ts
+++ b/src/modules/groups/entities/group.entity.ts
@@ -6,10 +6,12 @@ import {
 	UpdateDateColumn,
 	ManyToOne,
 	JoinColumn,
+	Index,
 } from 'typeorm';
 import { User } from '../../common/entities/user.entity';
 
 @Entity({ name: 'groups', schema: 'users' })
+@Index('IDX_groups_owner_id', ['ownerId'])
 export class Group {
 	@PrimaryGeneratedColumn('uuid')
 	id: string;

--- a/src/modules/sanctions/entities/user-sanction.entity.ts
+++ b/src/modules/sanctions/entities/user-sanction.entity.ts
@@ -6,10 +6,13 @@ import {
 	UpdateDateColumn,
 	ManyToOne,
 	JoinColumn,
+	Index,
 } from 'typeorm';
 import { User } from '../../common/entities/user.entity';
 
 @Entity({ name: 'user_sanctions', schema: 'users' })
+@Index('IDX_user_sanctions_user_id', ['userId'])
+@Index('IDX_user_sanctions_user_active', ['userId', 'active'])
 export class UserSanction {
 	@PrimaryGeneratedColumn('uuid')
 	id: string;


### PR DESCRIPTION
## Summary
- Adds @Index('IDX_blocked_users_blocker_id') and @Index('IDX_blocked_users_blocked_id') on BlockedUser - both columns appear in WHERE clauses in blocked-users.repository.ts
- Adds @Index('IDX_groups_owner_id') on Group.ownerId - used in findByOwnerId query
- Adds @Index('IDX_appeals_user_id'), @Index('IDX_appeals_status'), and composite @Index('IDX_appeals_user_id_status') on Appeal - used in findByUserId and findPending queries
- Adds @Index('IDX_user_sanctions_user_id') and composite @Index('IDX_user_sanctions_user_active') on UserSanction - userId is a hot query column
- No API or behavior change - pure metadata annotations that TypeORM materializes on next migration:generate

## Test plan
- [x] 818 unit tests green
- [x] ESLint clean