### PR TITLE
[WHISPR-1344] fix(profile): raise short throttle to 30/s on /profile/:id

### DIFF
--- a/src/modules/profile/controllers/profile.controller.ts
+++ b/src/modules/profile/controllers/profile.controller.ts
@@ -34,11 +34,15 @@ export class ProfileController {
 	}
 
 	// Profil tiers : haute mais bornee, on coupe les bots qui scannent (WHISPR-1327).
+	// WHISPR-1344 : ConversationsList charge en burst tous les profils membres
+	// d une session (jusqu a 30+ chats directs), le palier short de 10/s
+	// faisait sauter 20+ requetes en 429. Endpoint authentifie, pas exposable
+	// publiquement, on peut relacher sans degrader la protection anti-bot.
 	@Get(':id')
 	@Throttle({
-		short: { ttl: 1000, limit: 10 },
-		medium: { ttl: 10_000, limit: 60 },
-		long: { ttl: 60_000, limit: 120 },
+		short: { ttl: 1000, limit: 30 },
+		medium: { ttl: 10_000, limit: 100 },
+		long: { ttl: 60_000, limit: 300 },
 	})
 	@ApiOperation({ summary: 'Get user profile' })
 	@ApiParam({ name: 'id', type: 'string', format: 'uuid', description: 'User ID' })


### PR DESCRIPTION
## Summary

ConversationsList charge en burst tous les profils membres au load (30+ chats directs). Le palier short=10/s declenchait 20+ HTTP 429 par page load, laissant noms et avatars vides 30s.

## Diagnostic

Live Playwright preprod (sha-5f5e797 mobile-web) : 32 erreurs console 429 sur /user/v1/profile/:id, screen affiche "Utilisateur" + avatar U placeholder partout.

## Fix

Endpoint /profile/:id authentifie (JWT obligatoire), surface DoS publique = nulle. On peut relacher les paliers anti-bot sans degrader la protection :
- short: 10/s -> 30/s
- medium: 60/10s -> 100/10s
- long: 120/60s -> 300/60s

## Test plan
- [x] tsc clean
- [x] Existing throttle tests still pass (paliers gardent le meme semantic)
- [ ] Smoke test live post-deploy : 0 console 429 au load /ConversationsList

Closes WHISPR-1344