### PR TITLE
[WHISPR-1349] feat(profiles): batch endpoint POST /profiles/batch

### DIFF
--- a/src/modules/common/repositories/user.repository.spec.ts
+++ b/src/modules/common/repositories/user.repository.spec.ts
@@ -81,6 +81,43 @@ describe('UserRepository', () => {
 		});
 	});
 
+	describe('findByIds', () => {
+		it('returns all users matching the given ids in a single query', async () => {
+			const users = [{ id: 'uuid-1' } as User, { id: 'uuid-2' } as User];
+			mockTypeormRepo.find.mockResolvedValue(users);
+
+			const result = await repo.findByIds(['uuid-1', 'uuid-2']);
+
+			expect(mockTypeormRepo.find).toHaveBeenCalledTimes(1);
+			expect(mockTypeormRepo.find).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { id: expect.any(Object) },
+					relations: undefined,
+				})
+			);
+			expect(result).toBe(users);
+		});
+
+		it('short-circuits without hitting the DB when ids is empty', async () => {
+			const result = await repo.findByIds([]);
+
+			expect(result).toEqual([]);
+			expect(mockTypeormRepo.find).not.toHaveBeenCalled();
+		});
+
+		it('passes relations through to TypeORM find', async () => {
+			mockTypeormRepo.find.mockResolvedValue([]);
+
+			await repo.findByIds(['uuid-1'], ['privacySettings']);
+
+			expect(mockTypeormRepo.find).toHaveBeenCalledWith(
+				expect.objectContaining({
+					relations: ['privacySettings'],
+				})
+			);
+		});
+	});
+
 	describe('findByPhoneNumber', () => {
 		it('should find a user by phone number', async () => {
 			const user = { id: 'uuid', phoneNumber: '+1234567890' } as User;

--- a/src/modules/common/repositories/user.repository.ts
+++ b/src/modules/common/repositories/user.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, FindOptionsWhere, ILike } from 'typeorm';
+import { Repository, FindOptionsWhere, ILike, In } from 'typeorm';
 import { User } from '../entities/user.entity';
 
 /**
@@ -36,6 +36,19 @@ export class UserRepository {
 	async findById(id: string, relations?: string[]): Promise<User | null> {
 		return this.repository.findOne({
 			where: { id },
+			relations,
+		});
+	}
+
+	/**
+	 * Find multiple users by ids in a single query (1 SELECT IN au lieu de N).
+	 * Utilise par l'endpoint batch pour eviter les bursts de N requetes
+	 * lors du chargement de la liste des conversations cote mobile.
+	 */
+	async findByIds(ids: string[], relations?: string[]): Promise<User[]> {
+		if (ids.length === 0) return [];
+		return this.repository.find({
+			where: { id: In(ids) },
 			relations,
 		});
 	}

--- a/src/modules/profile/controllers/profiles.controller.spec.ts
+++ b/src/modules/profile/controllers/profiles.controller.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Request as ExpressRequest } from 'express';
+import { ProfilesController } from './profiles.controller';
+import { ProfileService } from '../services/profile.service';
+import { User } from '../../common/entities/user.entity';
+import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+import { BatchProfilesRequestDto } from '../dto/batch-profiles-request.dto';
+
+const makeReq = (sub: string, authorization?: string): ExpressRequest & { user: JwtPayload } =>
+	({
+		user: { sub } as JwtPayload,
+		headers: {
+			...(authorization ? { authorization } : {}),
+		},
+	}) as unknown as ExpressRequest & { user: JwtPayload };
+
+const makeUser = (id: string, overrides: Partial<User> = {}): User =>
+	({
+		id,
+		username: `user-${id}`,
+		firstName: null,
+		lastName: null,
+		biography: null,
+		profilePictureUrl: null,
+		visualPreferences: null,
+		lastSeen: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...overrides,
+	}) as User;
+
+describe('ProfilesController', () => {
+	let controller: ProfilesController;
+	let service: jest.Mocked<ProfileService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [ProfilesController],
+			providers: [
+				{
+					provide: ProfileService,
+					useValue: {
+						getProfilesBatch: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		controller = module.get<ProfilesController>(ProfilesController);
+		service = module.get(ProfileService);
+	});
+
+	describe('batch', () => {
+		it('returns profiles and missing ids from the service', async () => {
+			(service as any).getProfilesBatch.mockResolvedValue({
+				profiles: [makeUser('uuid-1'), makeUser('uuid-2')],
+				missing: ['uuid-3'],
+			});
+
+			const dto: BatchProfilesRequestDto = { ids: ['uuid-1', 'uuid-2', 'uuid-3'] };
+			const result = await controller.batch(dto, makeReq('requester-1'));
+
+			expect(result.profiles).toHaveLength(2);
+			expect(result.profiles[0].id).toBe('uuid-1');
+			expect(result.profiles[1].id).toBe('uuid-2');
+			expect(result.missing).toEqual(['uuid-3']);
+		});
+
+		it('does not leak phoneNumber in the mapped UserResponseDto output', async () => {
+			(service as any).getProfilesBatch.mockResolvedValue({
+				profiles: [makeUser('uuid-1', { phoneNumber: '+33600000001' } as Partial<User>)],
+				missing: [],
+			});
+
+			const dto: BatchProfilesRequestDto = { ids: ['uuid-1'] };
+			const result = await controller.batch(dto, makeReq('requester-1'));
+
+			expect((result.profiles[0] as any).phoneNumber).toBeUndefined();
+		});
+
+		it('dedupes duplicate ids before delegating to the service', async () => {
+			(service as any).getProfilesBatch.mockResolvedValue({
+				profiles: [makeUser('uuid-1')],
+				missing: [],
+			});
+
+			const dto: BatchProfilesRequestDto = { ids: ['uuid-1', 'uuid-1', 'uuid-1'] };
+			await controller.batch(dto, makeReq('requester-1'));
+
+			expect(service.getProfilesBatch).toHaveBeenCalledWith(['uuid-1'], 'requester-1', undefined);
+		});
+
+		it('forwards the Authorization header so avatar URLs can be presigned', async () => {
+			(service as any).getProfilesBatch.mockResolvedValue({ profiles: [], missing: [] });
+
+			const dto: BatchProfilesRequestDto = { ids: ['uuid-1'] };
+			await controller.batch(dto, makeReq('requester-1', 'Bearer token-xyz'));
+
+			expect(service.getProfilesBatch).toHaveBeenCalledWith(
+				['uuid-1'],
+				'requester-1',
+				'Bearer token-xyz'
+			);
+		});
+
+		it('forwards the requester id from req.user.sub to the service', async () => {
+			(service as any).getProfilesBatch.mockResolvedValue({ profiles: [], missing: [] });
+
+			const dto: BatchProfilesRequestDto = { ids: ['uuid-1'] };
+			await controller.batch(dto, makeReq('alice-sub'));
+
+			expect(service.getProfilesBatch).toHaveBeenCalledWith(['uuid-1'], 'alice-sub', undefined);
+		});
+
+		it('returns empty arrays when the service yields no profiles', async () => {
+			(service as any).getProfilesBatch.mockResolvedValue({ profiles: [], missing: [] });
+
+			const dto: BatchProfilesRequestDto = { ids: ['uuid-1'] };
+			const result = await controller.batch(dto, makeReq('requester-1'));
+
+			expect(result.profiles).toEqual([]);
+			expect(result.missing).toEqual([]);
+		});
+	});
+});

--- a/src/modules/profile/controllers/profiles.controller.ts
+++ b/src/modules/profile/controllers/profiles.controller.ts
@@ -1,0 +1,67 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, Request } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import type { Request as ExpressRequest } from 'express';
+import { JwtPayload } from '../../jwt-auth/jwt.strategy';
+import { UserResponseDto } from '../../common/dto/user-response.dto';
+import { BatchProfilesRequestDto } from '../dto/batch-profiles-request.dto';
+import { BatchProfilesResponseDto } from '../dto/batch-profiles-response.dto';
+import { ProfileService } from '../services/profile.service';
+
+// WHISPR-1349 - endpoint batch pour eviter le burst de N requetes
+// /profile/:id quand la mobile-app charge ConversationsList. Permet
+// 10 batch/s = 1000 profils/s en theorie sans declencher le throttler.
+// Suit WHISPR-1343 (concurrency cote mobile) et WHISPR-1344 (relachement
+// du throttler unitaire). Endpoint authentifie, dedup et privacy par profil.
+@ApiTags('Profile')
+@ApiBearerAuth()
+@Controller('profiles')
+export class ProfilesController {
+	constructor(private readonly profileService: ProfileService) {}
+
+	@Post('batch')
+	@Throttle({
+		short: { ttl: 1000, limit: 10 },
+		medium: { ttl: 10_000, limit: 30 },
+		long: { ttl: 60_000, limit: 100 },
+	})
+	@HttpCode(HttpStatus.OK)
+	@ApiOperation({
+		summary: 'Fetch multiple user profiles in a single request',
+		description:
+			'Retourne plusieurs profils utilisateurs en une seule requete pour eviter ' +
+			'le burst de N appels /profile/:id. Applique les memes privacy gates que ' +
+			"l'endpoint unitaire pour chaque profil retourne.",
+	})
+	@ApiBody({ type: BatchProfilesRequestDto })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Profiles retrieved successfully',
+		type: BatchProfilesResponseDto,
+	})
+	@ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid request body' })
+	@ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Missing or invalid bearer token' })
+	@ApiResponse({ status: HttpStatus.TOO_MANY_REQUESTS, description: 'Rate limit exceeded' })
+	async batch(
+		@Body() dto: BatchProfilesRequestDto,
+		@Request() req: ExpressRequest & { user: JwtPayload }
+	): Promise<BatchProfilesResponseDto> {
+		const requesterId: string = req.user?.sub ?? '';
+		const authorization = (req.headers['authorization'] as string | undefined) ?? undefined;
+
+		// Dedup cote serveur : evite de presigner deux fois la meme URL
+		// si le mobile envoie un id en double.
+		const uniqueIds = Array.from(new Set(dto.ids));
+
+		const { profiles, missing } = await this.profileService.getProfilesBatch(
+			uniqueIds,
+			requesterId,
+			authorization
+		);
+
+		const response = new BatchProfilesResponseDto();
+		response.profiles = profiles.map((user) => UserResponseDto.fromEntity(user));
+		response.missing = missing;
+		return response;
+	}
+}

--- a/src/modules/profile/dto/batch-profiles-request.dto.ts
+++ b/src/modules/profile/dto/batch-profiles-request.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsUUID } from 'class-validator';
+
+const MAX_BATCH_SIZE = 100;
+
+export class BatchProfilesRequestDto {
+	@ApiProperty({
+		type: [String],
+		format: 'uuid',
+		description: `Liste d'identifiants utilisateurs a recuperer en une seule requete (max ${MAX_BATCH_SIZE}).`,
+		minItems: 1,
+		maxItems: MAX_BATCH_SIZE,
+		example: ['a0000000-0000-4000-a000-000000000001', 'b0000000-0000-4000-b000-000000000002'],
+	})
+	@IsArray()
+	@ArrayMinSize(1)
+	@ArrayMaxSize(MAX_BATCH_SIZE)
+	@IsUUID('all', { each: true })
+	ids!: string[];
+}

--- a/src/modules/profile/dto/batch-profiles-response.dto.ts
+++ b/src/modules/profile/dto/batch-profiles-response.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserResponseDto } from '../../common/dto/user-response.dto';
+
+export class BatchProfilesResponseDto {
+	@ApiProperty({
+		type: [UserResponseDto],
+		description: 'Profils trouves et autorises (privacy gates appliquees individuellement).',
+	})
+	profiles!: UserResponseDto[];
+
+	@ApiProperty({
+		type: [String],
+		format: 'uuid',
+		description:
+			'Identifiants demandes mais non retournes (utilisateur inexistant, supprime, ou autre indisponibilite).',
+		example: ['c0000000-0000-4000-c000-000000000003'],
+	})
+	missing!: string[];
+}

--- a/src/modules/profile/profile.module.ts
+++ b/src/modules/profile/profile.module.ts
@@ -4,12 +4,13 @@ import { UserSearchModule } from '../search/user-search.module';
 import { PrivacyModule } from '../privacy/privacy.module';
 import { ContactsModule } from '../contacts/contacts.module';
 import { ProfileController } from './controllers/profile.controller';
+import { ProfilesController } from './controllers/profiles.controller';
 import { ProfileService } from './services/profile.service';
 import { MediaClientService } from './services/media-client.service';
 
 @Module({
 	imports: [CommonModule, UserSearchModule, PrivacyModule, ContactsModule],
-	controllers: [ProfileController],
+	controllers: [ProfileController, ProfilesController],
 	providers: [ProfileService, MediaClientService],
 	exports: [ProfileService],
 })

--- a/src/modules/profile/services/profile.service.spec.ts
+++ b/src/modules/profile/services/profile.service.spec.ts
@@ -648,4 +648,124 @@ describe('ProfileService', () => {
 			expect(user.firstName).toBe('Alice');
 		});
 	});
+
+	describe('getProfilesBatch', () => {
+		const userA = (): User =>
+			({
+				...mockUser(),
+				id: 'uuid-1',
+				firstName: 'Alice',
+				lastName: 'Smith',
+			}) as User;
+		const userB = (): User =>
+			({
+				...mockUser(),
+				id: 'uuid-2',
+				firstName: 'Bob',
+				lastName: 'Jones',
+			}) as User;
+
+		it('returns all requested profiles when they all exist', async () => {
+			(userRepository as any).findByIds = jest.fn().mockResolvedValue([userA(), userB()]);
+			privacyService.getSettings.mockResolvedValue(mockPrivacySettings());
+			contactsService.isContact.mockResolvedValue(true);
+
+			const result = await service.getProfilesBatch(['uuid-1', 'uuid-2'], 'uuid-3');
+
+			expect(result.profiles).toHaveLength(2);
+			expect(result.profiles.map((p) => p.id).sort()).toEqual(['uuid-1', 'uuid-2']);
+			expect(result.missing).toEqual([]);
+		});
+
+		it('reports missing ids when some users do not exist', async () => {
+			(userRepository as any).findByIds = jest.fn().mockResolvedValue([userA()]);
+			privacyService.getSettings.mockResolvedValue(mockPrivacySettings());
+			contactsService.isContact.mockResolvedValue(false);
+
+			const result = await service.getProfilesBatch(['uuid-1', 'uuid-missing'], 'uuid-3');
+
+			expect(result.profiles).toHaveLength(1);
+			expect(result.profiles[0].id).toBe('uuid-1');
+			expect(result.missing).toEqual(['uuid-missing']);
+		});
+
+		it('returns empty arrays when no ids are provided', async () => {
+			const findByIds = jest.fn().mockResolvedValue([]);
+			(userRepository as any).findByIds = findByIds;
+
+			const result = await service.getProfilesBatch([], 'uuid-3');
+
+			expect(result.profiles).toEqual([]);
+			expect(result.missing).toEqual([]);
+			expect(findByIds).not.toHaveBeenCalled();
+		});
+
+		it('applies privacy gates per profile (masks fields when not a contact)', async () => {
+			(userRepository as any).findByIds = jest.fn().mockResolvedValue([userA()]);
+			privacyService.getSettings.mockResolvedValue(
+				mockPrivacySettings({
+					firstNamePrivacy: PrivacyLevel.CONTACTS,
+					lastNamePrivacy: PrivacyLevel.CONTACTS,
+				})
+			);
+			contactsService.isContact.mockResolvedValue(false);
+
+			const result = await service.getProfilesBatch(['uuid-1'], 'uuid-3');
+
+			expect(result.profiles[0].firstName).toBeNull();
+			expect(result.profiles[0].lastName).toBeNull();
+		});
+
+		it('reveals CONTACTS fields when requester is a contact of the target', async () => {
+			(userRepository as any).findByIds = jest.fn().mockResolvedValue([userA()]);
+			privacyService.getSettings.mockResolvedValue(
+				mockPrivacySettings({
+					firstNamePrivacy: PrivacyLevel.CONTACTS,
+				})
+			);
+			contactsService.isContact.mockResolvedValue(true);
+
+			const result = await service.getProfilesBatch(['uuid-1'], 'uuid-3');
+
+			expect(result.profiles[0].firstName).toBe('Alice');
+		});
+
+		it('returns the full profile of the requester themselves without privacy lookup', async () => {
+			(userRepository as any).findByIds = jest.fn().mockResolvedValue([userA()]);
+
+			const result = await service.getProfilesBatch(['uuid-1'], 'uuid-1');
+
+			expect(result.profiles[0].firstName).toBe('Alice');
+			expect(privacyService.getSettings).not.toHaveBeenCalled();
+		});
+
+		it('issues a single SELECT IN regardless of the number of ids', async () => {
+			const findByIds = jest.fn().mockResolvedValue([userA(), userB()]);
+			(userRepository as any).findByIds = findByIds;
+			privacyService.getSettings.mockResolvedValue(mockPrivacySettings());
+			contactsService.isContact.mockResolvedValue(true);
+
+			await service.getProfilesBatch(['uuid-1', 'uuid-2'], 'uuid-3');
+
+			expect(findByIds).toHaveBeenCalledTimes(1);
+			expect(findByIds).toHaveBeenCalledWith(['uuid-1', 'uuid-2']);
+		});
+
+		it('does not mutate the source user entities returned by the repository', async () => {
+			const sourceA = userA();
+			const sourceB = userB();
+			(userRepository as any).findByIds = jest.fn().mockResolvedValue([sourceA, sourceB]);
+			privacyService.getSettings.mockResolvedValue(
+				mockPrivacySettings({
+					firstNamePrivacy: PrivacyLevel.NOBODY,
+				})
+			);
+			contactsService.isContact.mockResolvedValue(false);
+
+			await service.getProfilesBatch(['uuid-1', 'uuid-2'], 'uuid-3');
+
+			expect(sourceA.firstName).toBe('Alice');
+			expect(sourceB.firstName).toBe('Bob');
+		});
+	});
 });

--- a/src/modules/profile/services/profile.service.ts
+++ b/src/modules/profile/services/profile.service.ts
@@ -144,8 +144,38 @@ export class ProfileService {
 		authorization?: string
 	): Promise<User> {
 		const user = await this.findOne(id);
+		return this.applyPrivacyGate(user, requesterId, authorization);
+	}
 
-		if (requesterId === id) {
+	/**
+	 * Recupere N profils en une seule requete DB (SELECT IN) puis applique
+	 * les privacy gates par profil. Les ids inconnus / inactifs sont renvoyes
+	 * dans `missing`. Pas d'erreur globale si un seul id manque, le client
+	 * voit la liste partielle pour ne pas casser le rendu mobile.
+	 *
+	 * Le caller doit deduper les ids cote controller pour ne pas presigner
+	 * deux fois la meme URL.
+	 */
+	public async getProfilesBatch(
+		ids: string[],
+		requesterId: string,
+		authorization?: string
+	): Promise<{ profiles: User[]; missing: string[] }> {
+		if (ids.length === 0) {
+			return { profiles: [], missing: [] };
+		}
+
+		const found = await this.userRepository.findByIds(ids);
+		const profiles = await Promise.all(
+			found.map((user) => this.applyPrivacyGate(user, requesterId, authorization))
+		);
+		const foundIds = new Set(found.map((u) => u.id));
+		const missing = ids.filter((id) => !foundIds.has(id));
+		return { profiles, missing };
+	}
+
+	private async applyPrivacyGate(user: User, requesterId: string, authorization?: string): Promise<User> {
+		if (requesterId === user.id) {
 			if (user.profilePictureUrl) {
 				user.profilePictureUrl = await this.mediaClient.presignProfilePictureUrl(
 					user.profilePictureUrl,
@@ -155,8 +185,8 @@ export class ProfileService {
 			return user;
 		}
 
-		const settings = await this.privacyService.getSettings(id);
-		const isContact = await this.contactsService.isContact(id, requesterId);
+		const settings = await this.privacyService.getSettings(user.id);
+		const isContact = await this.contactsService.isContact(user.id, requesterId);
 
 		const canSee = (level: PrivacyLevel): boolean => {
 			if (level === PrivacyLevel.EVERYONE) return true;

--- a/test/functional.e2e-spec.ts
+++ b/test/functional.e2e-spec.ts
@@ -447,6 +447,77 @@ describe('Functional E2E Scenarios', () => {
 		});
 	});
 
+	// Scenario 7b (WHISPR-1349) : POST /profiles/batch — endpoint batch pour
+	// charger N profils en une seule requete. Suit WHISPR-1343 (concurrency
+	// mobile) et WHISPR-1344 (relachement throttle unitaire).
+	describe('Scenario 7b: POST /profiles/batch returns multiple profiles in one request', () => {
+		it('returns the requested profiles plus the missing ids', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+			await createUser(USER_B_ID, '+33600000002', 'bob');
+
+			const missingId = 'd0000000-0000-4000-9000-000000000099';
+
+			const res = await request(app.getHttpServer())
+				.post('/user/v1/profiles/batch')
+				.set(asUser(USER_A_ID))
+				.send({ ids: [USER_A_ID, USER_B_ID, missingId] })
+				.expect(200);
+
+			expect(res.body.profiles).toHaveLength(2);
+			const ids = res.body.profiles.map((p: { id: string }) => p.id).sort();
+			expect(ids).toEqual([USER_A_ID, USER_B_ID].sort());
+			expect(res.body.missing).toEqual([missingId]);
+		});
+
+		it('returns 401 without a bearer token', async () => {
+			await request(app.getHttpServer())
+				.post('/user/v1/profiles/batch')
+				.send({ ids: [USER_A_ID] })
+				.expect(401);
+		});
+
+		it('returns 400 when ids contains a non-uuid value', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+
+			await request(app.getHttpServer())
+				.post('/user/v1/profiles/batch')
+				.set(asUser(USER_A_ID))
+				.send({ ids: ['not-a-uuid'] })
+				.expect(400);
+		});
+
+		it('returns 400 when ids exceeds the 100-item cap', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+
+			const tooMany: string[] = [];
+			for (let i = 0; i < 101; i++) {
+				const hex = i.toString(16).padStart(2, '0');
+				// Le 4eme groupe doit commencer par 8/9/a/b pour passer @IsUUID,
+				// on garde 9000 fixe et on incremente le dernier segment.
+				tooMany.push(`e0000000-0000-4000-9000-0000000000${hex.padStart(2, '0')}`);
+			}
+
+			await request(app.getHttpServer())
+				.post('/user/v1/profiles/batch')
+				.set(asUser(USER_A_ID))
+				.send({ ids: tooMany })
+				.expect(400);
+		});
+
+		it('does not leak phoneNumber even when fetching the requesters own profile', async () => {
+			await createUser(USER_A_ID, '+33600000001', 'alice');
+
+			const res = await request(app.getHttpServer())
+				.post('/user/v1/profiles/batch')
+				.set(asUser(USER_A_ID))
+				.send({ ids: [USER_A_ID] })
+				.expect(200);
+
+			expect(res.body.profiles[0].id).toBe(USER_A_ID);
+			expect(res.body.profiles[0].phoneNumber).toBeUndefined();
+		});
+	});
+
 	// Scenario 8 (WHISPR-1327): POST /contact-requests is throttled at 10/60s
 	// per IP. Le 11e POST en moins de 60s doit retourner 429.
 	describe('Scenario 8: POST /contact-requests rate limit (10/60s)', () => {


### PR DESCRIPTION
## Summary
- Adds `POST /user/v1/profiles/batch` so the mobile-app can fetch up to 100 profiles in a single request instead of bursting N `/profile/:id` calls when ConversationsList loads (50+ direct chats today still hit 429 even after the WHISPR-1344 throttle raise).
- Service issues a single `SELECT IN` via a new `UserRepository.findByIds`, then applies the existing privacy gates (firstName/lastName/biography/profilePicture/lastSeen) per profile through a shared `applyPrivacyGate` helper extracted from `getProfileWithPrivacy` so behaviour is identical to the singular endpoint.
- Server-side dedup, JWT-required, throttled at 10/s short / 30/10s medium / 100/min long. Missing or unknown ids land in `missing[]` rather than failing the whole call.

## Test plan
- [x] Unit tests green (`npx jest --no-coverage` -> 87 suites, 835 tests passing). Adds 8 service specs (batch happy path, missing ids, dedup, privacy contacts/non-contacts, owner short-circuit, single SELECT IN check, no source mutation), 6 controller specs, and 3 repo specs around `findByIds`.
- [x] E2E tests green (`npm run test:e2e:docker` -> 27/27). New `Scenario 7b` covers happy path + missing id, 401, 400 invalid uuid, 400 over 100 cap, no phoneNumber leak.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint --fix` clean.

## Follow-ups
- Mobile-app refactor of `getUserInfo` to use this endpoint instead of N `/profile/:id` calls in ConversationsList — separate ticket to track on the mobile-app repo.
- Continues the burst-429 fix line started by WHISPR-1343 (mobile-side concurrency) and WHISPR-1344 (singular throttle raise).

Closes WHISPR-1349