### PR TITLE
[WHISPR-1380] chore(observability): TypeORM slow query log

### DIFF
--- a/src/typeorm.config.ts
+++ b/src/typeorm.config.ts
@@ -46,6 +46,8 @@ function getDataSourceOptions(configService: ConfigService): DataSourceOptions {
 		migrations: [__dirname + '/database/migrations/*{.ts,.js}'],
 		migrationsRun: configService.get('DB_MIGRATIONS_RUN', 'false') === 'true',
 		synchronize: configService.get('DB_SYNCHRONIZE', 'false') === 'true',
+		// Log queries qui prennent plus de 500ms via le logger NestJS pour detecter les slow queries en prod.
+		maxQueryExecutionTime: 500,
 	};
 }
 


### PR DESCRIPTION
## Summary
- Ajout de `maxQueryExecutionTime: 500` dans la config TypeORM (`src/typeorm.config.ts`).
- Permet de detecter en log les queries lentes (notamment `search-index.service` sur grands datasets).

## Test plan
- [x] `npx jest` 839/839 green
- [x] Lint clean
- [x] Diff = 2 lignes ajoutees, aucune autre modif

Closes WHISPR-1380