### PR TITLE
[WHISPR-1408] fix(security): webhook secret + replay + timeout

### DIFF
--- a/src/modules/webhooks/entities/webhook.entity.ts
+++ b/src/modules/webhooks/entities/webhook.entity.ts
@@ -11,7 +11,8 @@ export class Webhook {
 	@Column({ type: 'jsonb', default: [] })
 	events: string[];
 
-	@Column({ type: 'varchar', length: 255, nullable: true })
+	// secret: select false par defaut, addSelect explicite seulement quand on signe (WHISPR-1408)
+	@Column({ type: 'varchar', length: 255, nullable: true, select: false })
 	secret: string | null;
 
 	@Column({ type: 'boolean', default: true })

--- a/src/modules/webhooks/repositories/webhooks.repository.spec.ts
+++ b/src/modules/webhooks/repositories/webhooks.repository.spec.ts
@@ -2,6 +2,7 @@ import { WebhooksRepository } from './webhooks.repository';
 import { Webhook } from '../entities/webhook.entity';
 
 const mockQb = {
+	addSelect: jest.fn().mockReturnThis(),
 	where: jest.fn().mockReturnThis(),
 	andWhere: jest.fn().mockReturnThis(),
 	getMany: jest.fn(),
@@ -118,6 +119,15 @@ describe('WebhooksRepository', () => {
 				event: JSON.stringify(['sanction.created']),
 			});
 			expect(result).toBe(hooks);
+		});
+
+		// secret est select:false par defaut sur l'entity, doit etre re-inclus explicitement pour signer (WHISPR-1408)
+		it('explicitly addSelect webhook.secret for HMAC signing', async () => {
+			mockQb.getMany.mockResolvedValue([]);
+
+			await repo.findActiveByEvent('sanction.created');
+
+			expect(mockQb.addSelect).toHaveBeenCalledWith('webhook.secret');
 		});
 	});
 

--- a/src/modules/webhooks/repositories/webhooks.repository.ts
+++ b/src/modules/webhooks/repositories/webhooks.repository.ts
@@ -26,9 +26,11 @@ export class WebhooksRepository {
 		return this.repo.findOne({ where: { id } });
 	}
 
+	// addSelect du secret: usage strict pour signer le payload sortant (WHISPR-1408)
 	async findActiveByEvent(event: string): Promise<Webhook[]> {
 		return this.repo
 			.createQueryBuilder('webhook')
+			.addSelect('webhook.secret')
 			.where('webhook.active = true')
 			.andWhere('webhook.events @> :event', { event: JSON.stringify([event]) })
 			.getMany();

--- a/src/modules/webhooks/services/webhooks.service.spec.ts
+++ b/src/modules/webhooks/services/webhooks.service.spec.ts
@@ -139,7 +139,6 @@ describe('WebhooksService', () => {
 
 			const event: WebhookEvent = {
 				type: 'sanction.created',
-				timestamp: '2026-01-01T00:00:00Z',
 				data: { sanctionId: 'sanc-1' },
 			};
 
@@ -165,7 +164,6 @@ describe('WebhooksService', () => {
 
 			const event: WebhookEvent = {
 				type: 'sanction.created',
-				timestamp: '2026-01-01T00:00:00Z',
 				data: {},
 			};
 
@@ -181,7 +179,6 @@ describe('WebhooksService', () => {
 
 			const event: WebhookEvent = {
 				type: 'sanction.created',
-				timestamp: '2026-01-01T00:00:00Z',
 				data: {},
 			};
 
@@ -197,7 +194,6 @@ describe('WebhooksService', () => {
 
 			const event: WebhookEvent = {
 				type: 'sanction.created',
-				timestamp: '2026-01-01T00:00:00Z',
 				data: {},
 			};
 
@@ -211,13 +207,64 @@ describe('WebhooksService', () => {
 
 			const event: WebhookEvent = {
 				type: 'sanction.created',
-				timestamp: '2026-01-01T00:00:00Z',
 				data: {},
 			};
 
 			await service.dispatch(event);
 
 			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		it('should set timestamp server-side and ignore caller-supplied value', async () => {
+			const webhook = mockWebhook({ secret: null });
+			repo.findActiveByEvent.mockResolvedValue([webhook]);
+
+			const fixedNow = new Date('2026-05-09T10:30:00.000Z');
+			jest.useFakeTimers().setSystemTime(fixedNow);
+
+			// caller try to inject an old timestamp pour replay - doit etre ignore
+			const eventWithStaleTs = {
+				type: 'sanction.created',
+				timestamp: '2020-01-01T00:00:00.000Z',
+				data: {},
+			} as unknown as WebhookEvent;
+
+			await service.dispatch(eventWithStaleTs);
+
+			const sentBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+			expect(sentBody.timestamp).toBe(fixedNow.toISOString());
+			expect(sentBody.timestamp).not.toBe('2020-01-01T00:00:00.000Z');
+
+			jest.useRealTimers();
+		});
+
+		it('should attach an AbortSignal with 5s timeout on each fetch call', async () => {
+			const webhook = mockWebhook({ secret: null });
+			repo.findActiveByEvent.mockResolvedValue([webhook]);
+
+			const event: WebhookEvent = {
+				type: 'sanction.created',
+				data: {},
+			};
+
+			await service.dispatch(event);
+
+			const callArgs = fetchSpy.mock.calls[0][1];
+			expect(callArgs.signal).toBeInstanceOf(AbortSignal);
+		});
+
+		it('should swallow AbortError from fetch timeout', async () => {
+			const abortErr = new Error('The operation was aborted');
+			abortErr.name = 'TimeoutError';
+			fetchSpy.mockRejectedValue(abortErr);
+			repo.findActiveByEvent.mockResolvedValue([mockWebhook()]);
+
+			const event: WebhookEvent = {
+				type: 'sanction.created',
+				data: {},
+			};
+
+			await expect(service.dispatch(event)).resolves.toBeUndefined();
 		});
 	});
 });

--- a/src/modules/webhooks/services/webhooks.service.ts
+++ b/src/modules/webhooks/services/webhooks.service.ts
@@ -4,11 +4,18 @@ import { WebhooksRepository } from '../repositories/webhooks.repository';
 import { CreateWebhookDto } from '../dto/create-webhook.dto';
 import { Webhook } from '../entities/webhook.entity';
 
+// timestamp pose cote serveur dans dispatch(): un caller ne peut pas le forcer (anti-replay) (WHISPR-1408)
 export interface WebhookEvent {
 	type: string;
-	timestamp: string;
 	data: Record<string, any>;
 }
+
+// payload signe envoye au receiver: timestamp server-side, les receivers DOIVENT rejeter > 5 min
+export interface SignedWebhookPayload extends WebhookEvent {
+	timestamp: string;
+}
+
+const DISPATCH_TIMEOUT_MS = 5000;
 
 @Injectable()
 export class WebhooksService {
@@ -39,7 +46,13 @@ export class WebhooksService {
 
 	async dispatch(event: WebhookEvent): Promise<void> {
 		const webhooks = await this.webhooksRepository.findActiveByEvent(event.type);
-		const payload = JSON.stringify(event);
+		// timestamp force cote serveur: ignore tout champ caller-supplied pour bloquer le replay (WHISPR-1408)
+		const signedPayload: SignedWebhookPayload = {
+			type: event.type,
+			data: event.data,
+			timestamp: new Date().toISOString(),
+		};
+		const payload = JSON.stringify(signedPayload);
 
 		const dispatches = webhooks.map(async (webhook) => {
 			try {
@@ -53,10 +66,12 @@ export class WebhooksService {
 					headers['X-Webhook-Signature'] = `sha256=${signature}`;
 				}
 
+				// timeout dur sur fetch: pas de pile-up de Promises sur URL hung (WHISPR-1408)
 				await fetch(webhook.url, {
 					method: 'POST',
 					headers,
 					body: payload,
+					signal: AbortSignal.timeout(DISPATCH_TIMEOUT_MS),
 				});
 			} catch (error) {
 				this.logger.warn(


### PR DESCRIPTION
## Summary

Trois fixes securite sur le module webhooks:

- **HIGH** webhook secret stocke plaintext: column `secret` passe en `select: false`, ne fuit plus dans les SELECT *. Le repo `findActiveByEvent` fait un `addSelect('webhook.secret')` explicite uniquement pour signer le payload.
- **HIGH** replay protection: `WebhookEvent.timestamp` n'est plus accepte du caller. Le service le pose en `new Date().toISOString()` au moment du dispatch. Les receivers DOIVENT rejeter les events plus vieux que 5 min.
- **MEDIUM** fetch sans timeout: ajout de `signal: AbortSignal.timeout(5000)` sur le fetch sortant. Plus de pile-up sur URL hung.

## Test plan
- [x] Unit tests verts (853 passed)
- [x] Lint + prettier OK
- [x] Pre-push hook (e2e) passe
- [ ] Sonar quality gate OK
- [ ] Copilot review OK

Closes WHISPR-1408