### PR TITLE
[WHISPR-1413] fix(security): Cache-Control no-store global

### DIFF
--- a/src/interceptors/index.ts
+++ b/src/interceptors/index.ts
@@ -1,1 +1,2 @@
 export * from './logging.interceptor';
+export * from './no-cache.interceptor';

--- a/src/interceptors/no-cache.interceptor.spec.ts
+++ b/src/interceptors/no-cache.interceptor.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of, lastValueFrom } from 'rxjs';
+import { NoCacheInterceptor } from './no-cache.interceptor';
+
+describe('NoCacheInterceptor', () => {
+	let interceptor: NoCacheInterceptor;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [NoCacheInterceptor],
+		}).compile();
+
+		interceptor = module.get<NoCacheInterceptor>(NoCacheInterceptor);
+	});
+
+	const buildContext = (response: { setHeader: jest.Mock }) =>
+		({
+			switchToHttp: () => ({
+				getResponse: () => response,
+			}),
+		}) as unknown as ExecutionContext;
+
+	it('should be defined', () => {
+		expect(interceptor).toBeDefined();
+	});
+
+	it('sets Cache-Control: no-store and related anti-cache headers', async () => {
+		const setHeader = jest.fn();
+		const ctx = buildContext({ setHeader });
+		const next: CallHandler = { handle: () => of('ok') };
+
+		await lastValueFrom(interceptor.intercept(ctx, next));
+
+		expect(setHeader).toHaveBeenCalledWith(
+			'Cache-Control',
+			'no-store, no-cache, must-revalidate, private'
+		);
+		expect(setHeader).toHaveBeenCalledWith('Pragma', 'no-cache');
+		expect(setHeader).toHaveBeenCalledWith('Expires', '0');
+	});
+
+	it('passes through the next handler value', async () => {
+		const setHeader = jest.fn();
+		const ctx = buildContext({ setHeader });
+		const next: CallHandler = { handle: () => of({ id: 42 }) };
+
+		const value = await lastValueFrom(interceptor.intercept(ctx, next));
+
+		expect(value).toEqual({ id: 42 });
+	});
+});

--- a/src/interceptors/no-cache.interceptor.ts
+++ b/src/interceptors/no-cache.interceptor.ts
@@ -1,0 +1,17 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { Response } from 'express';
+
+// no-store global pour eviter cache PII via proxy/CDN/browser shared cache (WHISPR-1413).
+// NestJS et helmet n'emettent pas de Cache-Control par defaut, donc tout intermediaire
+// peut servir une reponse d'un user a un autre.
+@Injectable()
+export class NoCacheInterceptor implements NestInterceptor {
+	intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+		const res = context.switchToHttp().getResponse<Response>();
+		res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private');
+		res.setHeader('Pragma', 'no-cache');
+		res.setHeader('Expires', '0');
+		return next.handle();
+	}
+}

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -1,5 +1,5 @@
 import { Module, OnModuleDestroy } from '@nestjs/common';
-import { APP_GUARD } from '@nestjs/core';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerModule, ThrottlerOptions } from '@nestjs/throttler';
@@ -30,6 +30,7 @@ import { BackupsModule } from './backups/backups.module';
 import { InternalModule } from './internal/internal.module';
 import { JwtAuthModule } from './jwt-auth/jwt-auth.module';
 import { JwtAuthGuard } from './jwt-auth/jwt-auth.guard';
+import { NoCacheInterceptor } from '../interceptors/no-cache.interceptor';
 
 // Triple-tier global throttler aligned with media-service (WHISPR-1327):
 // short = burst protection, medium = sustained burst, long = global ceiling.
@@ -91,6 +92,10 @@ let throttlerRedisClient: Redis | null = null;
 		{
 			provide: APP_GUARD,
 			useClass: JwtAuthGuard,
+		},
+		{
+			provide: APP_INTERCEPTOR,
+			useClass: NoCacheInterceptor,
 		},
 	],
 })


### PR DESCRIPTION
## Summary
- Ajoute `NoCacheInterceptor` global qui set `Cache-Control: no-store, no-cache, must-revalidate, private` + `Pragma: no-cache` + `Expires: 0` sur toutes les reponses HTTP.
- NestJS et helmet n'emettent rien par defaut, donc tout proxy/CDN/browser shared cache pouvait servir une reponse PII (`/profile`, `/contacts`, audit CSV, etc.) d'un user a un autre.
- Le CSV export `/audit-logs/export` herite automatiquement (Bug 2 resolu via Bug 1).

## Test plan
- [x] Unit tests `NoCacheInterceptor` (header set, passthrough)
- [x] Suite complete jest 856 tests verts
- [x] Lint + prettier clean

Closes WHISPR-1413