### PR TITLE
[WHISPR-1422] fix(profile): phoneNumberMasked DTO

### DIFF
--- a/src/modules/common/dto/user-response.dto.spec.ts
+++ b/src/modules/common/dto/user-response.dto.spec.ts
@@ -76,6 +76,47 @@ describe('UserResponseDto', () => {
 			expect(dto.lastSeen).toBeNull();
 		});
 
+		it('expose phoneNumberMasked au format +XX***NNNN sans leak du numero complet', () => {
+			const user = {
+				id: 'user-mask',
+				phoneNumber: '+33612341234',
+				username: null,
+				firstName: null,
+				lastName: null,
+				biography: null,
+				profilePictureUrl: null,
+				lastSeen: null,
+				isActive: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			} as unknown as User;
+
+			const dto = UserResponseDto.fromEntity(user);
+
+			expect(dto.phoneNumberMasked).toBe('+33***1234');
+			expect((dto as any).phoneNumber).toBeUndefined();
+		});
+
+		it('phoneNumberMasked vaut null si phoneNumber est absent', () => {
+			const user = {
+				id: 'user-no-phone',
+				phoneNumber: null,
+				username: 'noPhone',
+				firstName: null,
+				lastName: null,
+				biography: null,
+				profilePictureUrl: null,
+				lastSeen: null,
+				isActive: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			} as unknown as User;
+
+			const dto = UserResponseDto.fromEntity(user);
+
+			expect(dto.phoneNumberMasked).toBeNull();
+		});
+
 		it('preserves null values for nullable string fields', () => {
 			const user = {
 				id: 'user-3',

--- a/src/modules/common/dto/user-response.dto.ts
+++ b/src/modules/common/dto/user-response.dto.ts
@@ -1,9 +1,16 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { User, UserVisualPreferences } from '../entities/user.entity';
+import { maskPhone } from '../../../utils/mask-phone.util';
 
 export class UserResponseDto {
 	@ApiProperty()
 	id: string;
+
+	@ApiPropertyOptional({
+		nullable: true,
+		description: 'Numero de telephone masque pour fallback display (ex: +33***1234)',
+	})
+	phoneNumberMasked: string | null;
 
 	@ApiPropertyOptional({ nullable: true })
 	username: string | null;
@@ -41,6 +48,7 @@ export class UserResponseDto {
 	static fromEntity(user: User): UserResponseDto {
 		const dto = new UserResponseDto();
 		dto.id = user.id;
+		dto.phoneNumberMasked = maskPhone(user.phoneNumber);
 		dto.username = user.username;
 		dto.firstName = user.firstName;
 		dto.lastName = user.lastName;

--- a/src/utils/mask-phone.util.spec.ts
+++ b/src/utils/mask-phone.util.spec.ts
@@ -1,0 +1,27 @@
+import { maskPhone } from './mask-phone.util';
+
+describe('maskPhone', () => {
+	it('masque un numero francais au format +33***1234', () => {
+		expect(maskPhone('+33612341234')).toBe('+33***1234');
+	});
+
+	it('masque un numero international en gardant prefixe et 4 derniers chiffres', () => {
+		expect(maskPhone('+14155551234')).toBe('+14***1234');
+	});
+
+	it('renvoie null si phone est null', () => {
+		expect(maskPhone(null)).toBeNull();
+	});
+
+	it('renvoie null si phone est undefined', () => {
+		expect(maskPhone(undefined)).toBeNull();
+	});
+
+	it('renvoie null si phone est trop court (< 7 caracteres)', () => {
+		expect(maskPhone('+12345')).toBeNull();
+	});
+
+	it('renvoie null si phone est une chaine vide', () => {
+		expect(maskPhone('')).toBeNull();
+	});
+});

--- a/src/utils/mask-phone.util.ts
+++ b/src/utils/mask-phone.util.ts
@@ -1,0 +1,12 @@
+/**
+ * Masque un numero de telephone pour affichage public.
+ * Garde le prefixe (3 premiers caracteres) et les 4 derniers chiffres.
+ * Ex: +33612341234 -> +33***1234
+ *
+ * Sert de fallback display pour les users sans username/firstName,
+ * pour eviter le placeholder "Utilisateur" cote mobile.
+ */
+export function maskPhone(phone: string | null | undefined): string | null {
+	if (!phone || phone.length < 7) return null;
+	return `${phone.slice(0, 3)}***${phone.slice(-4)}`;
+}


### PR DESCRIPTION
## Summary

Sur preprod, plusieurs DM affichent "Utilisateur" parce que la fallback chain mobile (`displayName` -> `username` -> `phoneNumber` -> "Utilisateur") tombe sur le placeholder.

Cause :
- `firstName` / `lastName` masques par privacy CONTACTS (requester non-contact)
- `username` null en DB (user pas setupe)
- `phoneNumber` jamais expose dans `UserResponseDto` pour les non-self

Fix :
- Nouveau helper `maskPhone()` qui retourne `+33***1234` (3 premiers + masque + 4 derniers)
- Champ `phoneNumberMasked: string \| null` ajoute au `UserResponseDto`
- `fromEntity` setter : `dto.phoneNumberMasked = maskPhone(user.phoneNumber)`
- Le numero brut n'est JAMAIS expose, seulement la version masquee

Le mobile peut maintenant utiliser `phoneNumberMasked` comme dernier fallback avant "Utilisateur".

## Files

- `src/utils/mask-phone.util.ts` (new)
- `src/utils/mask-phone.util.spec.ts` (new)
- `src/modules/common/dto/user-response.dto.ts`
- `src/modules/common/dto/user-response.dto.spec.ts`

## Test plan

- [x] Unit tests green (864 passed)
- [x] E2E tests green (27 passed)
- [x] Lint clean
- [x] Pas de leak `phoneNumber` brut dans le DTO (test inclus)

Closes WHISPR-1422