### PR TITLE
[WHISPR-1432] fix(profile): accept non-RFC UUIDs in batch profiles DTO

### DIFF
--- a/src/modules/profile/dto/batch-profiles-request.dto.spec.ts
+++ b/src/modules/profile/dto/batch-profiles-request.dto.spec.ts
@@ -1,0 +1,77 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { BatchProfilesRequestDto } from './batch-profiles-request.dto';
+
+function makeDto(ids: string[]): BatchProfilesRequestDto {
+	const dto = new BatchProfilesRequestDto();
+	dto.ids = ids;
+	return dto;
+}
+
+describe('BatchProfilesRequestDto', () => {
+	describe('ids validation', () => {
+		it('accepte un UUID v4 standard', async () => {
+			const errors = await validate(makeDto(['dd536f14-71c9-45c8-8b4f-1c912b8e3d43']));
+			expect(errors).toHaveLength(0);
+		});
+
+		it('accepte un UUID v4 standard en majuscules', async () => {
+			const errors = await validate(makeDto(['DD536F14-71C9-45C8-8B4F-1C912B8E3D43']));
+			expect(errors).toHaveLength(0);
+		});
+
+		// IDs seed du messaging-service : nibble de version = 0 (non-RFC)
+		// Ces IDs sont en production et doivent passer la validation.
+		it('accepte les IDs seed messaging-service (nibble version 0)', async () => {
+			const errors = await validate(
+				makeDto([
+					'a0000002-0000-0000-0000-000000000002',
+					'a0000005-0000-0000-0000-000000000005',
+					'a0000008-0000-0000-0000-000000000008',
+					'a0000001-0000-0000-0000-000000000001',
+				])
+			);
+			expect(errors).toHaveLength(0);
+		});
+
+		it('accepte un mix UUID RFC et UUID seed', async () => {
+			const errors = await validate(
+				makeDto(['dd536f14-71c9-45c8-8b4f-1c912b8e3d43', 'a0000002-0000-0000-0000-000000000002'])
+			);
+			expect(errors).toHaveLength(0);
+		});
+
+		it('rejette une chaine non-UUID', async () => {
+			const errors = await validate(makeDto(['not-a-uuid']));
+			expect(errors.length).toBeGreaterThan(0);
+		});
+
+		it('rejette un UUID avec un segment manquant', async () => {
+			const errors = await validate(makeDto(['dd536f14-71c9-45c8-8b4f']));
+			expect(errors.length).toBeGreaterThan(0);
+		});
+
+		it('rejette un tableau vide (ArrayMinSize)', async () => {
+			const errors = await validate(makeDto([]));
+			expect(errors.length).toBeGreaterThan(0);
+		});
+
+		it('rejette plus de 100 ids (ArrayMaxSize)', async () => {
+			const ids = Array.from(
+				{ length: 101 },
+				(_, i) => `a${String(i).padStart(7, '0')}-0000-0000-0000-${String(i).padStart(12, '0')}`
+			);
+			const errors = await validate(makeDto(ids));
+			expect(errors.length).toBeGreaterThan(0);
+		});
+
+		it('accepte exactement 100 ids (limite haute)', async () => {
+			const ids = Array.from(
+				{ length: 100 },
+				(_, i) => `a${String(i).padStart(7, '0')}-0000-0000-0000-${String(i).padStart(12, '0')}`
+			);
+			const errors = await validate(makeDto(ids));
+			expect(errors).toHaveLength(0);
+		});
+	});
+});

--- a/src/modules/profile/dto/batch-profiles-request.dto.ts
+++ b/src/modules/profile/dto/batch-profiles-request.dto.ts
@@ -1,7 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { ArrayMaxSize, ArrayMinSize, IsArray, IsUUID } from 'class-validator';
+import { ArrayMaxSize, ArrayMinSize, IsArray, Matches } from 'class-validator';
 
 const MAX_BATCH_SIZE = 100;
+
+// Accepte tout UUID en 8-4-4-4-12 hex, quel que soit le nibble de version.
+// @IsUUID('all') impose les versions RFC 1-5 et rejette les IDs seed du
+// messaging-service (ex: a0000002-0000-0000-0000-000000000002) dont le
+// nibble vaut 0. Ces IDs sont valides en production et doivent passer.
+const UUID_LOOSE_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export class BatchProfilesRequestDto {
 	@ApiProperty({
@@ -15,6 +21,6 @@ export class BatchProfilesRequestDto {
 	@IsArray()
 	@ArrayMinSize(1)
 	@ArrayMaxSize(MAX_BATCH_SIZE)
-	@IsUUID('all', { each: true })
+	@Matches(UUID_LOOSE_RE, { each: true, message: 'each value in ids must be a UUID' })
 	ids!: string[];
 }


### PR DESCRIPTION
## Summary

- `@IsUUID('all', { each: true })` enforces RFC version nibble 1-5 and silently rejects messaging-service seed IDs (e.g. `a0000002-0000-0000-0000-000000000002`) whose version nibble is `0`.
- Every call from the mobile app to `POST /user/v1/profiles/batch` returned 400 because conversation member lists mix RFC UUIDs and these seed IDs.
- Fix: replace with `@Matches(UUID_LOOSE_RE, ...)` that validates 8-4-4-4-12 hex format without enforcing the RFC version nibble. The error message is preserved (`each value in ids must be a UUID`) so callers are unaffected.

## Test plan

- [x] New DTO spec covers: RFC v4 UUID, uppercase UUID, seed IDs (nibble 0), mixed batch, non-UUID rejection, empty array rejection, >100 ids rejection, exactly-100 acceptance
- [x] Existing controller spec still green
- [x] `npm test` - 873 unit tests pass
- [x] `npm run test:e2e:docker` - 27 E2E tests pass (Scenario 7b explicitly covers `/profiles/batch`)
- [x] Lint and prettier clean

Closes WHISPR-1432