### PR TITLE
fix(ci): scope cd token to user-service + infrastructure repos

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           app-id: ${{ secrets.ACTIONS_CD }}
           private-key: ${{ secrets.ACTIONS_CD_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            user-service
+            infrastructure
 
       - name: Checkout user-service
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Le step `Generate GitHub App Token` ne specifiait pas `owner` + `repositories`, donc le token genere etait scope au seul repo courant (user-service).
- Resultat : `Update Deployment Manifest` echouait sur le push vers `whispr-messenger/infrastructure` avec `403 Permission denied to actions-cd[bot]`.
- Fix : ajout de `owner` + liste explicite `user-service` (clone source) + `infrastructure` (push target).

## Test plan
- [ ] Lint CI green
- [ ] Apres merge : rerun manuel CD via `workflow_dispatch`
- [ ] Verifier que le push vers `whispr-messenger/infrastructure` reussit
- [ ] Verifier le bump de `infrastructure/k8s/whispr/prod/user-service/deployment.yaml` au SHA `8d59da7`