### PR TITLE
chore(sonar): rename displayed project to user-service

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarCloud project configuration
 sonar.organization=whispr-messenger
 sonar.projectKey=whispr-messenger_user-service
-sonar.projectName=User Service
+sonar.projectName=user-service
 sonar.projectDescription=User management service for Whispr application
 
 # Source and test directories


### PR DESCRIPTION
## Summary

Renames `sonar.projectName` from `User Service` to `user-service` in `sonar-project.properties` to align the displayed Sonar project name with the GitHub repository name.

The `sonar.projectKey` (`whispr-messenger_user-service`) is unchanged, so historical data is preserved.

PR de maintenance non liée à un ticket Jira — préfixe `[WHISPR-XXX]` volontairement omis (chore non-ticket conformément à l'exception documentée dans CLAUDE.md).

## Test plan

- [ ] CI verte
- [ ] SonarCloud UI affiche `user-service` après la prochaine analyse